### PR TITLE
Team invites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
           java-version: '25'
           cache: maven
 
-      - name: Build and install MockBukkit dev/26.1.1
-        run: |
-          git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
-
       - name: Run Checkstyle
         run: mvn -B -ntp -pl teams-api checkstyle:check
 
@@ -51,7 +46,7 @@ jobs:
       - name: Build and install MockBukkit dev/26.1.1
         run: |
           git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
 
       - name: Compile
         run: mvn -B -ntp -DskipTests compile
@@ -81,7 +76,7 @@ jobs:
       - name: Build and install MockBukkit dev/26.1.1
         run: |
           git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
 
       - name: Package
         run: mvn -B -ntp -DskipTests package
@@ -118,7 +113,7 @@ jobs:
       - name: Build and install MockBukkit dev/26.1.1
         run: |
           git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
 
       - name: Build plugin JAR
         run: mvn -B -ntp -DskipTests package

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Your Plugin (consumer)  →  TeamsAPI (bridge)  →  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -61,7 +61,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.0.1'
+    compileOnly 'com.github.ez-plugins:teams-api:1.1.0'
 }
 ```
 
@@ -97,9 +97,36 @@ public void onDisable() {
 }
 ```
 
+### Invite service (optional)
+
+If the active team plugin also supports invitations, a `TeamsInviteService` is available:
+
+```java
+if (TeamsAPI.isInviteAvailable()) {
+    TeamsInviteService invites = TeamsAPI.getInviteService();
+    invites.invitePlayer(teamId, sender.getUniqueId(), target.getUniqueId());
+}
+```
+
+Providers that support invitations register the service alongside `TeamsService`:
+
+```java
+@Override
+public void onEnable() {
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerInviteProvider(this, inviteService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterInviteProvider(inviteService);
+}
+```
+
 ### Events
 
-All provider events are cancellable and extend `TeamEvent`:
+Provider events extend `TeamEvent`. Core events are cancellable; invite result events are informational:
 
 ```java
 @EventHandler
@@ -107,6 +134,11 @@ public void onTeamJoin(TeamJoinEvent event) {
     if (event.getTeam().getSize() >= 10) {
         event.setCancelled(true);
     }
+}
+
+@EventHandler
+public void onInviteAccepted(TeamInviteAcceptEvent event) {
+    // player has already joined — informational only
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,8 @@ This document describes each type in the `teams-api` artifact.
 
 Entry point for all API interactions. All methods are static.
 
+**Core service**
+
 | Method | Description |
 |--------|-------------|
 | `getService()` | Returns the active `TeamsService`, or `null` if none is registered. |
@@ -29,6 +31,30 @@ Entry point for all API interactions. All methods are static.
 | `registerProvider(plugin, service, priority)` | Registers a provider at the given priority. |
 | `unregisterProvider(service)` | Unregisters a provider from Bukkit's ServicesManager. |
 | `API_VERSION` | The current API version string (Semantic Versioning). |
+
+**Invite service**
+
+| Method | Description |
+|--------|-------------|
+| `getInviteService()` | Returns the active `TeamsInviteService`, or `null` if none is registered. |
+| `isInviteAvailable()` | Returns `true` when an invite provider is registered. |
+| `registerInviteProvider(plugin, service)` | Registers an invite provider at `ServicePriority.Normal`. |
+| `registerInviteProvider(plugin, service, priority)` | Registers an invite provider at the given priority. |
+| `unregisterInviteProvider(service)` | Unregisters an invite provider from Bukkit's ServicesManager. |
+
+---
+
+## `TeamsInviteService` (interface)
+
+Optional extension service for team invitation flows. Providers that support
+invitations register an implementation via `TeamsAPI.registerInviteProvider()`.
+Existing `TeamsService` implementations are **not required** to support it.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `invitePlayer(teamId, inviterUUID, inviteeUUID)` | `boolean` | Sends an invitation. Providers should fire `TeamInviteEvent` before recording it; return `false` if cancelled or a pending invite already exists. |
+| `acceptInvite(teamId, playerUUID)` | `Optional<Team>` | Accepts a pending invitation and adds the player as `MEMBER`. Empty if no invite exists or the join failed. |
+| `declineInvite(teamId, playerUUID)` | `boolean` | Removes a pending invitation. Returns `false` if none existed. |
 
 ---
 
@@ -128,6 +154,8 @@ Helper methods:
 All events extend `TeamEvent` which extends Bukkit's `Event`.
 All concrete events implement `Cancellable`.
 
+**Core events** (all cancellable)
+
 | Class | Key fields |
 |-------|------------|
 | `TeamCreateEvent` | `getTeam()`, `getCreatorUUID()` |
@@ -136,9 +164,26 @@ All concrete events implement `Cancellable`.
 | `TeamLeaveEvent` | `getTeam()`, `getPlayerUUID()`, `getFormerRole()` |
 | `TeamRoleChangeEvent` | `getTeam()`, `getPlayerUUID()`, `getOldRole()`, `getNewRole()` |
 
+**Invite events**
+
+| Class | Cancellable | Key fields |
+|-------|-------------|------------|
+| `TeamInviteEvent` | Yes | `getTeam()`, `getInviterUUID()`, `getInviteeUUID()` |
+| `TeamInviteAcceptEvent` | No | `getTeam()`, `getPlayerUUID()` |
+| `TeamInviteDeclineEvent` | No | `getTeam()`, `getPlayerUUID()` |
+
 ---
 
 ## Migration notes
+
+### 1.1.0
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- New optional `TeamsInviteService` interface for invitation flows.
+- New `TeamsAPI` static methods: `getInviteService()`, `isInviteAvailable()`,
+  `registerInviteProvider(...)`, `unregisterInviteProvider(...)`.
+- New events: `TeamInviteEvent` (cancellable), `TeamInviteAcceptEvent`, `TeamInviteDeclineEvent`.
 
 ### 1.0.0
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -74,8 +74,7 @@ from the team plugin directly. Providers register and unregister themselves via
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.0.1</version>
-    <scope>provided</scope>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -86,7 +85,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.0.1'
+    compileOnly 'com.github.ez-plugins:teams-api:1.1.0'
 }
 ```
 
@@ -127,7 +126,53 @@ public void onDisable() {
 }
 ```
 
-### 4. Declare the soft-dependency in `plugin.yml`
+### 4. Optionally implement `TeamsInviteService`
+
+If your plugin supports team invitations, implement and register `TeamsInviteService`
+alongside `TeamsService`:
+
+```java
+public class MyInviteService implements TeamsInviteService {
+
+    @Override
+    public boolean invitePlayer(UUID teamId, UUID inviterUUID, UUID inviteeUUID) {
+        // Fire TeamInviteEvent first; return false if cancelled
+    }
+
+    @Override
+    public Optional<Team> acceptInvite(UUID teamId, UUID playerUUID) {
+        // Add player, fire TeamInviteAcceptEvent, return the team
+    }
+
+    @Override
+    public boolean declineInvite(UUID teamId, UUID playerUUID) {
+        // Remove pending invite, fire TeamInviteDeclineEvent
+    }
+}
+```
+
+Register and unregister it alongside `TeamsService`:
+
+```java
+private MyTeamsService teamsService;
+private MyInviteService inviteService;
+
+@Override
+public void onEnable() {
+    teamsService = new MyTeamsService(this);
+    inviteService = new MyInviteService(this);
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerInviteProvider(this, inviteService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterInviteProvider(inviteService);
+}
+```
+
+### 5. Declare the soft-dependency in `plugin.yml`
 
 ```yaml
 softdepend:
@@ -183,13 +228,25 @@ private void handlePlayerCommand(Player player) {
 }
 ```
 
+If your plugin also wants to send invitations, check for `TeamsInviteService`:
+
+```java
+private void handleInviteCommand(Player sender, Player target, UUID teamId) {
+    if (!TeamsAPI.isInviteAvailable()) {
+        sender.sendMessage("The active team plugin does not support invitations.");
+        return;
+    }
+    TeamsInviteService invites = TeamsAPI.getInviteService();
+    boolean sent = invites.invitePlayer(teamId, sender.getUniqueId(), target.getUniqueId());
+    sender.sendMessage(sent ? "Invitation sent!" : "Could not send invitation.");
+}
+```
+
 ---
 
 ## Events
 
-All events are in the `com.skyblockexp.teamsapi.event` package.
-Providers are **encouraged** to fire these events; whether they do is
-implementation-specific.
+**Core events** — providers are **encouraged** to fire these; whether they do is implementation-specific.
 
 | Event                  | When fired                          | Cancellable |
 |------------------------|-------------------------------------|-------------|
@@ -199,7 +256,15 @@ implementation-specific.
 | `TeamLeaveEvent`       | Before a player leaves a team       | Yes         |
 | `TeamRoleChangeEvent`  | Before a member's role changes      | Yes         |
 
-Example listener:
+**Invite events** — fired by providers that implement `TeamsInviteService`.
+
+| Event                    | When fired                                 | Cancellable |
+|--------------------------|--------------------------------------------|-------------|
+| `TeamInviteEvent`        | Before an invitation is recorded           | Yes         |
+| `TeamInviteAcceptEvent`  | After the player has joined the team       | No          |
+| `TeamInviteDeclineEvent` | After the pending invitation was removed   | No          |
+
+Example listeners:
 
 ```java
 @EventHandler
@@ -211,6 +276,16 @@ public void onTeamJoin(TeamJoinEvent event) {
         event.setCancelled(true);
         // Notify player that the team is full
     }
+}
+
+@EventHandler
+public void onInvite(TeamInviteEvent event) {
+    // Cancel to block the invitation
+}
+
+@EventHandler
+public void onInviteAccepted(TeamInviteAcceptEvent event) {
+    // Informational — player has already joined
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <!-- Allow CI to override Paper API version via -Dpaper.version -->
         <paper.version>[26.1.2.build,)</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
-        <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
-        <mockbukkit.version>dev-d245e0a</mockbukkit.version>
+        <mockbukkit.artifactId>mockbukkit-v1.21</mockbukkit.artifactId>
+        <mockbukkit.version>4.109.0</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft — bridges team plugins with a clean, timeless interface.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <maven.compiler.target>25</maven.compiler.target>
         <maven.compiler.release>25</maven.compiler.release>
         <!-- Allow CI to override Paper API version via -Dpaper.version -->
-        <paper.version>[26.1.2.build,)</paper.version>
+        <paper.version>26.1.2.build.57-stable</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
-        <mockbukkit.artifactId>mockbukkit-v1.21</mockbukkit.artifactId>
-        <mockbukkit.version>4.109.0</mockbukkit.version>
+        <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
+        <mockbukkit.version>dev-7fba375</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -45,7 +45,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.0.1";
+    public static final String API_VERSION = "1.1.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }
@@ -147,5 +147,100 @@ public final class TeamsAPI {
         }
 
         Bukkit.getServicesManager().unregister(TeamsService.class, provider);
+    }
+
+    // -------------------------------------------------------------------------
+    // Invite provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsInviteService} provider, or {@code null}
+     * if no invite provider has been registered.
+     *
+     * <p>Consumers should check {@link #isInviteAvailable()} before calling this method
+     * to handle gracefully the case where no team plugin supports invitations.</p>
+     *
+     * @return the active {@link TeamsInviteService}, or {@code null} if unavailable
+     */
+    public static TeamsInviteService getInviteService() {
+        try {
+            final RegisteredServiceProvider<TeamsInviteService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsInviteService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsInviteService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if an invite provider is available, {@code false} otherwise
+     */
+    public static boolean isInviteAvailable() {
+        return getInviteService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsInviteService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsInviteService} implementation; must not be {@code null}
+     */
+    public static void registerInviteProvider(final Plugin plugin,
+            final TeamsInviteService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsInviteService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsInviteService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsInviteService} implementation; must not be {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerInviteProvider(
+            final Plugin plugin,
+            final TeamsInviteService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsInviteService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsInviteService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsInviteService} provider to unregister; may be {@code null}
+     */
+    public static void unregisterInviteProvider(final TeamsInviteService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsInviteService.class, provider);
     }
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsInviteService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsInviteService.java
@@ -1,0 +1,85 @@
+package com.skyblockexp.teamsapi.api;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Optional extension service for team invitation flows.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to support
+ * invitations register an implementation separately via
+ * {@link TeamsAPI#registerInviteProvider(org.bukkit.plugin.Plugin, TeamsInviteService)}.
+ * Consumers first check whether the service is available with
+ * {@link TeamsAPI#isInviteAvailable()} before calling {@link TeamsAPI#getInviteService()}.</p>
+ *
+ * <p>Existing {@link TeamsService} implementations are not required to implement this
+ * interface; omitting it is a supported configuration and the API will degrade gracefully.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // In your team plugin's onEnable():
+ * TeamsAPI.registerInviteProvider(this, new MyInviteServiceImpl());
+ *
+ * // In your team plugin's onDisable():
+ * TeamsAPI.unregisterInviteProvider(myInviteService);
+ * }</pre>
+ *
+ * <p><strong>Consumer usage example:</strong></p>
+ * <pre>{@code
+ * TeamsInviteService invites = TeamsAPI.getInviteService();
+ * if (invites == null) {
+ *     player.sendMessage("Invitations are not supported by the active team plugin.");
+ *     return;
+ * }
+ * invites.invitePlayer(teamId, sender.getUniqueId(), target.getUniqueId());
+ * }</pre>
+ */
+public interface TeamsInviteService {
+
+    /**
+     * Invites the given player to the given team on behalf of the given inviter.
+     *
+     * <p>Providers should fire {@link com.skyblockexp.teamsapi.event.TeamInviteEvent} before
+     * recording the invitation. If the event is cancelled, implementations should return
+     * {@code false}.</p>
+     *
+     * @param teamId      the UUID of the team; must not be {@code null}
+     * @param inviterUUID the UUID of the player sending the invitation; must not be {@code null}
+     * @param inviteeUUID the UUID of the player being invited; must not be {@code null}
+     * @return {@code true} if the invitation was successfully recorded, {@code false} otherwise
+     *         (e.g. the team does not exist, the player is already a member, or a pending
+     *         invitation already exists)
+     */
+    boolean invitePlayer(UUID teamId, UUID inviterUUID, UUID inviteeUUID);
+
+    /**
+     * Accepts a pending invitation for the given player to join the given team.
+     *
+     * <p>Implementations should add the player to the team as a
+     * {@link com.skyblockexp.teamsapi.model.TeamRole#MEMBER} and fire
+     * {@link com.skyblockexp.teamsapi.event.TeamInviteAcceptEvent} after the player has
+     * been added successfully.</p>
+     *
+     * @param teamId     the UUID of the team; must not be {@code null}
+     * @param playerUUID the UUID of the invited player accepting the invitation; must not be
+     *                   {@code null}
+     * @return an {@link Optional} containing the {@link Team} the player has joined, or empty
+     *         if no pending invitation exists for that player or the join failed
+     */
+    Optional<Team> acceptInvite(UUID teamId, UUID playerUUID);
+
+    /**
+     * Declines a pending invitation for the given player to the given team.
+     *
+     * <p>Implementations should fire {@link com.skyblockexp.teamsapi.event.TeamInviteDeclineEvent}
+     * after the invitation has been removed.</p>
+     *
+     * @param teamId     the UUID of the team; must not be {@code null}
+     * @param playerUUID the UUID of the invited player declining the invitation; must not be
+     *                   {@code null}
+     * @return {@code true} if a pending invitation existed and was removed, {@code false} otherwise
+     */
+    boolean declineInvite(UUID teamId, UUID playerUUID);
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteAcceptEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteAcceptEvent.java
@@ -1,0 +1,60 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired after a player has accepted a team invitation and joined the team.
+ *
+ * <p>This event is informational; it is fired after the player has already been
+ * added to the team. It cannot be cancelled.</p>
+ */
+public class TeamInviteAcceptEvent extends TeamEvent {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The UUID of the player who accepted the invitation. */
+    private final UUID playerUUID;
+
+    /**
+     * Creates a new {@link TeamInviteAcceptEvent}.
+     *
+     * @param team       the team the player has joined; must not be {@code null}
+     * @param playerUUID the UUID of the player who accepted the invitation; must not be
+     *                   {@code null}
+     */
+    public TeamInviteAcceptEvent(final Team team, final UUID playerUUID) {
+        super(team);
+        this.playerUUID = playerUUID;
+    }
+
+    /**
+     * Returns the UUID of the player who accepted the invitation.
+     *
+     * @return the player's UUID; never {@code null}
+     */
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteDeclineEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteDeclineEvent.java
@@ -1,0 +1,60 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired after a player has declined a team invitation.
+ *
+ * <p>This event is informational; it is fired after the pending invitation has
+ * already been removed. It cannot be cancelled.</p>
+ */
+public class TeamInviteDeclineEvent extends TeamEvent {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The UUID of the player who declined the invitation. */
+    private final UUID playerUUID;
+
+    /**
+     * Creates a new {@link TeamInviteDeclineEvent}.
+     *
+     * @param team       the team whose invitation was declined; must not be {@code null}
+     * @param playerUUID the UUID of the player who declined the invitation; must not be
+     *                   {@code null}
+     */
+    public TeamInviteDeclineEvent(final Team team, final UUID playerUUID) {
+        super(team);
+        this.playerUUID = playerUUID;
+    }
+
+    /**
+     * Returns the UUID of the player who declined the invitation.
+     *
+     * @return the player's UUID; never {@code null}
+     */
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamInviteEvent.java
@@ -1,0 +1,95 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a player is about to be invited to a team.
+ *
+ * <p>Providers should fire this event before recording the invitation. If the event is
+ * cancelled, the invitation must not be recorded and
+ * {@link com.skyblockexp.teamsapi.api.TeamsService#invitePlayer} should return
+ * {@code false}.</p>
+ */
+public class TeamInviteEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The UUID of the player who is sending the invitation. */
+    private final UUID inviterUUID;
+
+    /** The UUID of the player who is being invited. */
+    private final UUID inviteeUUID;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamInviteEvent}.
+     *
+     * @param team        the team the player is being invited to; must not be {@code null}
+     * @param inviterUUID the UUID of the player sending the invitation; must not be {@code null}
+     * @param inviteeUUID the UUID of the player being invited; must not be {@code null}
+     */
+    public TeamInviteEvent(final Team team, final UUID inviterUUID, final UUID inviteeUUID) {
+        super(team);
+        this.inviterUUID = inviterUUID;
+        this.inviteeUUID = inviteeUUID;
+    }
+
+    /**
+     * Returns the UUID of the player who is sending the invitation.
+     *
+     * @return the inviter's UUID; never {@code null}
+     */
+    public UUID getInviterUUID() {
+        return inviterUUID;
+    }
+
+    /**
+     * Returns the UUID of the player who is being invited.
+     *
+     * @return the invitee's UUID; never {@code null}
+     */
+    public UUID getInviteeUUID() {
+        return inviteeUUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIInviteTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIInviteTest.java
@@ -1,0 +1,173 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsInviteService} registration methods on {@link TeamsAPI}.
+ *
+ * <p>Tests verify that the invite service facade correctly delegates to Bukkit's
+ * ServicesManager and that null-safety contracts hold, mirroring {@link TeamsAPITest}.</p>
+ */
+class TeamsAPIInviteTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isInviteAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isInviteAvailable()} returns {@code false} when no invite provider
+     * has been registered.
+     */
+    @Test
+    void isInviteAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isInviteAvailable());
+    }
+
+    /**
+     * getInviteService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getInviteService()} returns {@code null} when no invite provider
+     * has been registered.
+     */
+    @Test
+    void getInviteService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getInviteService());
+    }
+
+    /**
+     * registerInviteProvider_makesInviteServiceAvailable verifies that after registering
+     * an invite provider, {@link TeamsAPI#isInviteAvailable()} returns {@code true} and
+     * {@link TeamsAPI#getInviteService()} returns the registered provider.
+     */
+    @Test
+    void registerInviteProvider_makesInviteServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(plugin, mockInvite);
+
+        assertTrue(TeamsAPI.isInviteAvailable());
+        assertEquals(mockInvite, TeamsAPI.getInviteService());
+    }
+
+    /**
+     * unregisterInviteProvider_makesInviteServiceUnavailable verifies that after
+     * unregistering an invite provider, {@link TeamsAPI#isInviteAvailable()} returns
+     * {@code false}.
+     */
+    @Test
+    void unregisterInviteProvider_makesInviteServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(plugin, mockInvite);
+        TeamsAPI.unregisterInviteProvider(mockInvite);
+
+        assertFalse(TeamsAPI.isInviteAvailable());
+    }
+
+    /**
+     * registerInviteProvider_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin does not register anything.
+     */
+    @Test
+    void registerInviteProvider_withNullPlugin_doesNotRegister() {
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(null, mockInvite);
+
+        assertFalse(TeamsAPI.isInviteAvailable());
+    }
+
+    /**
+     * registerInviteProvider_withNullProvider_doesNotRegister verifies that passing a
+     * {@code null} provider does not register anything.
+     */
+    @Test
+    void registerInviteProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerInviteProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isInviteAvailable());
+    }
+
+    /**
+     * unregisterInviteProvider_withNull_doesNotThrow verifies that passing {@code null}
+     * to {@link TeamsAPI#unregisterInviteProvider(TeamsInviteService)} does not throw.
+     */
+    @Test
+    void unregisterInviteProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterInviteProvider(null);
+        // No exception expected
+    }
+
+    /**
+     * registerInviteProvider_withPriority_registersCorrectly verifies that the overload
+     * accepting a {@link org.bukkit.plugin.ServicePriority} registers the invite provider
+     * successfully.
+     */
+    @Test
+    void registerInviteProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(plugin, mockInvite,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isInviteAvailable());
+        assertEquals(mockInvite, TeamsAPI.getInviteService());
+    }
+
+    /**
+     * registerInviteProvider_withPriority_withNullPriority_doesNotRegister verifies that
+     * passing a {@code null} priority does not register anything.
+     */
+    @Test
+    void registerInviteProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(plugin, mockInvite, null);
+
+        assertFalse(TeamsAPI.isInviteAvailable());
+    }
+
+    /**
+     * inviteService_isIndependentOfTeamsService verifies that registering only an invite
+     * provider does not affect {@link TeamsAPI#isAvailable()}, and vice versa.
+     */
+    @Test
+    void inviteService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsInviteService mockInvite = mock(TeamsInviteService.class);
+
+        TeamsAPI.registerInviteProvider(plugin, mockInvite);
+
+        assertTrue(TeamsAPI.isInviteAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamInviteEventTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamInviteEventTest.java
@@ -1,0 +1,246 @@
+package com.skyblockexp.teamsapi.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+/**
+ * Unit tests for the team invitation events:
+ * {@link TeamInviteEvent}, {@link TeamInviteAcceptEvent}, and {@link TeamInviteDeclineEvent}.
+ *
+ * <p>Tests verify constructors, getters, cancellable behaviour, and that each event
+ * exposes the correct static {@link org.bukkit.event.HandlerList}.</p>
+ */
+class TeamInviteEventTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamInviteEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamInviteEvent_getTeam_returnsTeam verifies that {@link TeamInviteEvent#getTeam()}
+     * returns the team passed to the constructor.
+     */
+    @Test
+    void teamInviteEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final UUID inviter = UUID.randomUUID();
+        final UUID invitee = UUID.randomUUID();
+        final TeamInviteEvent event = new TeamInviteEvent(team, inviter, invitee);
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamInviteEvent_getInviterUUID_returnsInviter verifies that
+     * {@link TeamInviteEvent#getInviterUUID()} returns the inviter UUID passed to
+     * the constructor.
+     */
+    @Test
+    void teamInviteEvent_getInviterUUID_returnsInviter() {
+        final Team team = mock(Team.class);
+        final UUID inviter = UUID.randomUUID();
+        final UUID invitee = UUID.randomUUID();
+        final TeamInviteEvent event = new TeamInviteEvent(team, inviter, invitee);
+
+        assertEquals(inviter, event.getInviterUUID());
+    }
+
+    /**
+     * teamInviteEvent_getInviteeUUID_returnsInvitee verifies that
+     * {@link TeamInviteEvent#getInviteeUUID()} returns the invitee UUID passed to
+     * the constructor.
+     */
+    @Test
+    void teamInviteEvent_getInviteeUUID_returnsInvitee() {
+        final Team team = mock(Team.class);
+        final UUID inviter = UUID.randomUUID();
+        final UUID invitee = UUID.randomUUID();
+        final TeamInviteEvent event = new TeamInviteEvent(team, inviter, invitee);
+
+        assertEquals(invitee, event.getInviteeUUID());
+    }
+
+    /**
+     * teamInviteEvent_isCancelled_returnsFalse_byDefault verifies that
+     * {@link TeamInviteEvent} is not cancelled by default.
+     */
+    @Test
+    void teamInviteEvent_isCancelled_returnsFalse_byDefault() {
+        final TeamInviteEvent event = new TeamInviteEvent(mock(Team.class),
+            UUID.randomUUID(), UUID.randomUUID());
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamInviteEvent_setCancelled_returnsTrue_whenCancelled verifies that cancelling
+     * a {@link TeamInviteEvent} causes {@link TeamInviteEvent#isCancelled()} to return
+     * {@code true}.
+     */
+    @Test
+    void teamInviteEvent_setCancelled_returnsTrue_whenCancelled() {
+        final TeamInviteEvent event = new TeamInviteEvent(mock(Team.class),
+            UUID.randomUUID(), UUID.randomUUID());
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    /**
+     * teamInviteEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamInviteEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamInviteEvent.getHandlerList());
+    }
+
+    /**
+     * teamInviteEvent_getHandlers_matchesStaticHandlerList verifies that
+     * {@link TeamInviteEvent#getHandlers()} returns the same instance as the static
+     * {@code getHandlerList()} method.
+     */
+    @Test
+    void teamInviteEvent_getHandlers_matchesStaticHandlerList() {
+        final TeamInviteEvent event = new TeamInviteEvent(mock(Team.class),
+            UUID.randomUUID(), UUID.randomUUID());
+
+        assertEquals(TeamInviteEvent.getHandlerList(), event.getHandlers());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamInviteAcceptEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamInviteAcceptEvent_getTeam_returnsTeam verifies that
+     * {@link TeamInviteAcceptEvent#getTeam()} returns the team passed to the constructor.
+     */
+    @Test
+    void teamInviteAcceptEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final UUID player = UUID.randomUUID();
+        final TeamInviteAcceptEvent event = new TeamInviteAcceptEvent(team, player);
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamInviteAcceptEvent_getPlayerUUID_returnsPlayer verifies that
+     * {@link TeamInviteAcceptEvent#getPlayerUUID()} returns the player UUID passed to
+     * the constructor.
+     */
+    @Test
+    void teamInviteAcceptEvent_getPlayerUUID_returnsPlayer() {
+        final Team team = mock(Team.class);
+        final UUID player = UUID.randomUUID();
+        final TeamInviteAcceptEvent event = new TeamInviteAcceptEvent(team, player);
+
+        assertEquals(player, event.getPlayerUUID());
+    }
+
+    /**
+     * teamInviteAcceptEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamInviteAcceptEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamInviteAcceptEvent.getHandlerList());
+    }
+
+    /**
+     * teamInviteAcceptEvent_getHandlers_matchesStaticHandlerList verifies that
+     * {@link TeamInviteAcceptEvent#getHandlers()} returns the same instance as the static
+     * {@code getHandlerList()} method.
+     */
+    @Test
+    void teamInviteAcceptEvent_getHandlers_matchesStaticHandlerList() {
+        final TeamInviteAcceptEvent event = new TeamInviteAcceptEvent(mock(Team.class),
+            UUID.randomUUID());
+
+        assertEquals(TeamInviteAcceptEvent.getHandlerList(), event.getHandlers());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamInviteDeclineEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamInviteDeclineEvent_getTeam_returnsTeam verifies that
+     * {@link TeamInviteDeclineEvent#getTeam()} returns the team passed to the constructor.
+     */
+    @Test
+    void teamInviteDeclineEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final UUID player = UUID.randomUUID();
+        final TeamInviteDeclineEvent event = new TeamInviteDeclineEvent(team, player);
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamInviteDeclineEvent_getPlayerUUID_returnsPlayer verifies that
+     * {@link TeamInviteDeclineEvent#getPlayerUUID()} returns the player UUID passed to
+     * the constructor.
+     */
+    @Test
+    void teamInviteDeclineEvent_getPlayerUUID_returnsPlayer() {
+        final Team team = mock(Team.class);
+        final UUID player = UUID.randomUUID();
+        final TeamInviteDeclineEvent event = new TeamInviteDeclineEvent(team, player);
+
+        assertEquals(player, event.getPlayerUUID());
+    }
+
+    /**
+     * teamInviteDeclineEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamInviteDeclineEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamInviteDeclineEvent.getHandlerList());
+    }
+
+    /**
+     * teamInviteDeclineEvent_getHandlers_matchesStaticHandlerList verifies that
+     * {@link TeamInviteDeclineEvent#getHandlers()} returns the same instance as the static
+     * {@code getHandlerList()} method.
+     */
+    @Test
+    void teamInviteDeclineEvent_getHandlers_matchesStaticHandlerList() {
+        final TeamInviteDeclineEvent event = new TeamInviteDeclineEvent(mock(Team.class),
+            UUID.randomUUID());
+
+        assertEquals(TeamInviteDeclineEvent.getHandlerList(), event.getHandlers());
+    }
+}


### PR DESCRIPTION
## What's new in 1.1.0 - Team Invite API

### New: `TeamsInviteService` interface

An optional, independent service interface for team invitation flows.
Providers that support invitations register an implementation separately
via `TeamsAPI.registerInviteProvider()`. Existing `TeamsService` implementations
are not required to support it; the API degrades gracefully when no invite
provider is registered.

Methods:

- `invitePlayer(UUID teamId, UUID inviterUUID, UUID inviteeUUID) → boolean`
- `acceptInvite(UUID teamId, UUID playerUUID) → Optional<Team>`
- `declineInvite(UUID teamId, UUID playerUUID) → boolean`

### New: invite provider management on `TeamsAPI`

- `TeamsAPI.getInviteService()` - returns the registered `TeamsInviteService`, or `null`
- `TeamsAPI.isInviteAvailable()` - returns `true` if an invite provider is registered
- `TeamsAPI.registerInviteProvider(Plugin, TeamsInviteService)` - registers at `Normal` priority
- `TeamsAPI.registerInviteProvider(Plugin, TeamsInviteService, ServicePriority)` - registers at a custom priority
- `TeamsAPI.unregisterInviteProvider(TeamsInviteService)` - unregisters the provider on disable

All methods follow the existing null-safety contract (null arguments are silently ignored).

### New events

| Event | Cancellable | When fired |
|---|---|---|
| `TeamInviteEvent` | Yes | Before an invitation is recorded. Cancel to block it. |
| `TeamInviteAcceptEvent` | No | After the player has joined the team. |
| `TeamInviteDeclineEvent` | No | After the pending invitation has been removed. |

### Version bump

`TeamsAPI.API_VERSION` and all `pom.xml` versions updated from `1.0.1` to `1.1.0`.