### PR TITLE
feat: add team warp service, events, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,22 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
+          cd /tmp/MockBukkit
+          VERSION="dev-$(git rev-parse --short HEAD)"
+          echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
+          ./gradlew jar generatePomFileForMavenPublication -x test
+          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
+          POM=$(find build/publications -name 'pom-default.xml' | head -1)
+          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
 
       - name: Compile
-        run: mvn -B -ntp -DskipTests compile
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} compile
 
       - name: Run unit tests
-        run: mvn -B -ntp -pl teams-api test
+        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} test
 
       - name: Coverage report
-        run: mvn -B -ntp -pl teams-api jacoco:report
+        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} jacoco:report
 
   package:
     name: Package Plugin
@@ -76,10 +82,16 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
+          cd /tmp/MockBukkit
+          VERSION="dev-$(git rev-parse --short HEAD)"
+          echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
+          ./gradlew jar generatePomFileForMavenPublication -x test
+          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
+          POM=$(find build/publications -name 'pom-default.xml' | head -1)
+          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
 
       - name: Package
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
 
       - name: Upload plugin JAR
         uses: actions/upload-artifact@v4
@@ -113,13 +125,19 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
+          cd /tmp/MockBukkit
+          VERSION="dev-$(git rev-parse --short HEAD)"
+          echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
+          ./gradlew jar generatePomFileForMavenPublication -x test
+          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
+          POM=$(find build/publications -name 'pom-default.xml' | head -1)
+          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
 
       - name: Build plugin JAR
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
 
       - name: Publish Maven artifacts
-        run: mvn -B -ntp -DskipTests -pl teams-api deploy
+        run: mvn -B -ntp -DskipTests -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew publishToMavenLocal -x test -x signMavenPublication
+          ./gradlew publishToMavenLocal -x test
 
       - name: Compile
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} compile
@@ -82,7 +82,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew publishToMavenLocal -x test -x signMavenPublication
+          ./gradlew publishToMavenLocal -x test
 
       - name: Package
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
@@ -122,7 +122,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew publishToMavenLocal -x test -x signMavenPublication
+          ./gradlew publishToMavenLocal -x test
 
       - name: Build plugin JAR
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew jar generatePomFileForMavenPublication -x test
-          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
-          POM=$(find build/publications -name 'pom-default.xml' | head -1)
-          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
+          ./gradlew publishToMavenLocal -x test -x signMavenPublication
 
       - name: Compile
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} compile
@@ -85,10 +82,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew jar generatePomFileForMavenPublication -x test
-          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
-          POM=$(find build/publications -name 'pom-default.xml' | head -1)
-          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
+          ./gradlew publishToMavenLocal -x test -x signMavenPublication
 
       - name: Package
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
@@ -128,10 +122,7 @@ jobs:
           cd /tmp/MockBukkit
           VERSION="dev-$(git rev-parse --short HEAD)"
           echo "MOCKBUKKIT_VERSION=$VERSION" >> "$GITHUB_ENV"
-          ./gradlew jar generatePomFileForMavenPublication -x test
-          JAR=$(find build/libs -maxdepth 1 -name '*.jar' ! -name '*-sources*' ! -name '*-javadoc*' | head -1)
-          POM=$(find build/publications -name 'pom-default.xml' | head -1)
-          mvn install:install-file -Dfile="$JAR" -DpomFile="$POM"
+          ./gradlew publishToMavenLocal -x test -x signMavenPublication
 
       - name: Build plugin JAR
         run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,19 +43,20 @@ jobs:
           java-version: '25'
           cache: maven
 
-      - name: Build and install MockBukkit dev/26.1.1
+      - name: Build and install MockBukkit minecraft/v26
         run: |
-          git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
+          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Compile
-        run: mvn -B -ntp -DskipTests compile
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} compile
 
       - name: Run unit tests
-        run: mvn -B -ntp -pl teams-api test
+        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} test
 
       - name: Coverage report
-        run: mvn -B -ntp -pl teams-api jacoco:report
+        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} jacoco:report
 
   package:
     name: Package Plugin
@@ -73,13 +74,14 @@ jobs:
           java-version: '25'
           cache: maven
 
-      - name: Build and install MockBukkit dev/26.1.1
+      - name: Build and install MockBukkit minecraft/v26
         run: |
-          git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
+          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Package
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
 
       - name: Upload plugin JAR
         uses: actions/upload-artifact@v4
@@ -110,16 +112,17 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Build and install MockBukkit dev/26.1.1
+      - name: Build and install MockBukkit minecraft/v26
         run: |
-          git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && git checkout 7fba375 && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
+          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
+          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Build plugin JAR
-        run: mvn -B -ntp -DskipTests package
+        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
 
       - name: Publish Maven artifacts
-        run: mvn -B -ntp -DskipTests -pl teams-api deploy
+        run: mvn -B -ntp -DskipTests -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,16 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
-          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
 
       - name: Compile
-        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} compile
+        run: mvn -B -ntp -DskipTests compile
 
       - name: Run unit tests
-        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} test
+        run: mvn -B -ntp -pl teams-api test
 
       - name: Coverage report
-        run: mvn -B -ntp -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} jacoco:report
+        run: mvn -B -ntp -pl teams-api jacoco:report
 
   package:
     name: Package Plugin
@@ -77,11 +76,10 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
-          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
 
       - name: Package
-        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
+        run: mvn -B -ntp -DskipTests package
 
       - name: Upload plugin JAR
         uses: actions/upload-artifact@v4
@@ -115,14 +113,13 @@ jobs:
       - name: Build and install MockBukkit minecraft/v26
         run: |
           git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-          cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
-          echo "MOCKBUKKIT_VERSION=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          cd /tmp/MockBukkit && GITHUB_REPOSITORY=MockBukkit/MockBukkit ./gradlew publishToMavenLocal -x test -Pmockbukkit.version=ci-local
 
       - name: Build plugin JAR
-        run: mvn -B -ntp -DskipTests -Dmockbukkit.version=${MOCKBUKKIT_VERSION} package
+        run: mvn -B -ntp -DskipTests package
 
       - name: Publish Maven artifacts
-        run: mvn -B -ntp -DskipTests -pl teams-api -Dmockbukkit.version=${MOCKBUKKIT_VERSION} deploy
+        run: mvn -B -ntp -DskipTests -pl teams-api deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: TeamsAPI
 description: >-
-  Universal Teams API for Minecraft — a timeless bridge between team plugins
-  and the plugins that depend on them. Vault-style provider interface for Paper 26.1+.
+  Universal Teams API for Minecraft. A Vault-style bridge between team plugins
+  and the plugins that depend on them. Provider interface for Paper 26.1+.
 
 url: "https://ez-plugins.github.io"
 baseurl: "/teams-api"

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@ nav_order: 10
 description: "Complete public method tables for every class and interface in teams-api"
 ---
 
-# TeamsAPI — Public API Reference
+# API Reference
 {: .no_toc }
 
 This document describes each type in the `teams-api` artifact.
@@ -14,8 +14,6 @@ This document describes each type in the `teams-api` artifact.
 
 1. TOC
 {:toc}
-
----
 
 ## `TeamsAPI` (static facade)
 
@@ -42,21 +40,15 @@ Entry point for all API interactions. All methods are static.
 | `registerInviteProvider(plugin, service, priority)` | Registers an invite provider at the given priority. |
 | `unregisterInviteProvider(service)` | Unregisters an invite provider from Bukkit's ServicesManager. |
 
----
+**Warp service**
 
-## `TeamsInviteService` (interface)
-
-Optional extension service for team invitation flows. Providers that support
-invitations register an implementation via `TeamsAPI.registerInviteProvider()`.
-Existing `TeamsService` implementations are **not required** to support it.
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `invitePlayer(teamId, inviterUUID, inviteeUUID)` | `boolean` | Sends an invitation. Providers should fire `TeamInviteEvent` before recording it; return `false` if cancelled or a pending invite already exists. |
-| `acceptInvite(teamId, playerUUID)` | `Optional<Team>` | Accepts a pending invitation and adds the player as `MEMBER`. Empty if no invite exists or the join failed. |
-| `declineInvite(teamId, playerUUID)` | `boolean` | Removes a pending invitation. Returns `false` if none existed. |
-
----
+| Method | Description |
+|--------|-------------|
+| `getWarpService()` | Returns the active `TeamsWarpService`, or `null` if none is registered. |
+| `isWarpAvailable()` | Returns `true` when a warp provider is registered. |
+| `registerWarpProvider(plugin, service)` | Registers a warp provider at `ServicePriority.Normal`. |
+| `registerWarpProvider(plugin, service, priority)` | Registers a warp provider at the given priority. |
+| `unregisterWarpProvider(service)` | Unregisters a warp provider from Bukkit's ServicesManager. |
 
 ## `TeamsService` (interface)
 
@@ -97,7 +89,30 @@ Implemented by team plugins. Obtained via `TeamsAPI.getService()`.
 | `teamExists(name)` | `boolean` | Whether a team with that name exists. |
 | `isMember(teamId, playerUUID)` | `boolean` | Whether the player is a member of that team. |
 
----
+## `TeamsInviteService` (interface)
+
+Optional extension service for team invitation flows. Providers that support
+invitations register an implementation via `TeamsAPI.registerInviteProvider()`.
+Existing `TeamsService` implementations are not required to support it.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `invitePlayer(teamId, inviterUUID, inviteeUUID)` | `boolean` | Sends an invitation. Providers should fire `TeamInviteEvent` before recording it; return `false` if cancelled or a pending invite already exists. |
+| `acceptInvite(teamId, playerUUID)` | `Optional<Team>` | Accepts a pending invitation and adds the player as `MEMBER`. Empty if no invite exists or the join failed. |
+| `declineInvite(teamId, playerUUID)` | `boolean` | Removes a pending invitation. Returns `false` if none existed. |
+
+## `TeamsWarpService` (interface)
+
+Optional extension service for team warp management. Providers that support
+warps register an implementation via `TeamsAPI.registerWarpProvider()`.
+Existing `TeamsService` implementations are not required to support it.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setWarp(teamId, name, location, creatorUUID)` | `boolean` | Creates or updates a named warp. Providers should fire `TeamWarpSetEvent` before persisting; return `false` if cancelled or the team does not exist. |
+| `removeWarp(teamId, name)` | `boolean` | Removes the named warp. Providers should fire `TeamWarpDeleteEvent` before removing; return `false` if cancelled or no such warp exists. |
+| `getWarp(teamId, name)` | `Optional<TeamWarp>` | Returns the named warp, or empty if it does not exist. |
+| `getWarps(teamId)` | `Collection<TeamWarp>` | Returns all warps for the team. Never `null`; empty if the team has no warps. |
 
 ## `Team` (interface)
 
@@ -117,8 +132,6 @@ A read-only snapshot of a team. Obtain via `TeamsService` lookup methods.
 | `isMember(playerUUID)` | `boolean` | Whether the player is a member (any role). |
 | `isOwner(playerUUID)` | `boolean` | Whether the player holds the OWNER role. |
 
----
-
 ## `TeamMember` (interface)
 
 A read-only record of a player's membership.
@@ -129,7 +142,18 @@ A read-only record of a player's membership.
 | `getRole()` | `TeamRole` | The role the player holds in the team. |
 | `getJoinedAt()` | `Instant` | When the player joined; may be `Instant.EPOCH` if unsupported. |
 
----
+## `TeamWarp` (interface)
+
+A read-only snapshot of a team warp point. Obtain via `TeamsWarpService` lookup
+methods.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getTeamId()` | `UUID` | The UUID of the team this warp belongs to. |
+| `getName()` | `String` | The warp name. Unique within a team; case-sensitivity is provider-defined. |
+| `getLocation()` | `Location` | The Bukkit `Location` this warp points to. |
+| `getCreatorUUID()` | `UUID` | UUID of the player who created or last updated this warp. |
+| `getCreatedAt()` | `Instant` | When the warp was created or last updated; may be `Instant.EPOCH` if unsupported. |
 
 ## `TeamRole` (enum)
 
@@ -146,8 +170,6 @@ Helper methods:
 | `getPriority()` | Numeric priority value. Higher = more authority. |
 | `outranks(other)` | Returns `true` if this role has a higher priority than `other`. |
 | `canManage(target)` | Returns `true` if this role can manage members of the `target` role. |
-
----
 
 ## Events
 
@@ -172,9 +194,24 @@ All concrete events implement `Cancellable`.
 | `TeamInviteAcceptEvent` | No | `getTeam()`, `getPlayerUUID()` |
 | `TeamInviteDeclineEvent` | No | `getTeam()`, `getPlayerUUID()` |
 
----
+**Warp events**
+
+| Class | Cancellable | Key fields |
+|-------|-------------|------------|
+| `TeamWarpSetEvent` | Yes | `getTeam()`, `getName()`, `getLocation()`, `getCreatorUUID()` |
+| `TeamWarpDeleteEvent` | Yes | `getTeam()`, `getName()` |
 
 ## Migration notes
+
+### 1.2.0
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- New optional `TeamsWarpService` interface for warp management.
+- New `TeamWarp` model interface.
+- New `TeamsAPI` static methods: `getWarpService()`, `isWarpAvailable()`,
+  `registerWarpProvider(...)`, `unregisterWarpProvider(...)`.
+- New events: `TeamWarpSetEvent` (cancellable), `TeamWarpDeleteEvent` (cancellable).
 
 ### 1.1.0
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Developer Guide
-nav_order: 2
+nav_order: 3
 has_children: true
 description: "Architecture overview, installation instructions, and consumer usage guide"
 ---

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,10 +1,11 @@
 ---
 title: Developer Guide
 nav_order: 2
-description: "Integration guide for providers (team plugins) and consumers"
+has_children: true
+description: "Architecture overview, installation instructions, and consumer usage guide"
 ---
 
-# TeamsAPI — Developer Guide
+# Developer Guide
 {: .no_toc }
 
 ## Table of contents
@@ -13,14 +14,10 @@ description: "Integration guide for providers (team plugins) and consumers"
 1. TOC
 {:toc}
 
----
-
 TeamsAPI is a passive bridge plugin, modelled on the same design philosophy as
 [Vault](https://github.com/MilkBowl/VaultAPI). It defines a standard interface
 for team operations so that any plugin needing team data can work with any
 compatible team plugin without coupling them together.
-
----
 
 ## Architecture
 
@@ -31,7 +28,7 @@ compatible team plugin without coupling them together.
               │  TeamsAPI.getService()
               ▼
 ┌───────────────────────────┐
-│       TeamsAPI             │  ← installed on the server as TeamsAPI.jar
+│       TeamsAPI             │  installed on the server as TeamsAPI.jar
 │  (static bridge facade)    │
 └─────────────┬─────────────┘
               │  Bukkit ServicesManager
@@ -42,22 +39,34 @@ compatible team plugin without coupling them together.
 └───────────────────────────┘
 ```
 
-Consumers depend only on the `teams-api` artifact — they never import classes
-from the team plugin directly. Providers register and unregister themselves via
+Consumers depend only on the `teams-api` artifact and never import classes from
+the team plugin directly. Providers register and unregister themselves through
 `TeamsAPI.registerProvider(...)`.
 
----
+The optional services (`TeamsInviteService` and `TeamsWarpService`) follow the
+same pattern: each is registered and looked up independently from the core
+service. A provider plugin can implement any combination of the three.
 
 ## Installation (server owners)
 
-1. Download `teams-api-plugin-VERSION.jar` from the Releases page.
+1. Download `teams-api-plugin-VERSION.jar` from the [Releases page](https://github.com/ez-plugins/teams-api/releases).
 2. Place it in your server's `plugins/` directory.
 3. Install a compatible team plugin that provides a `TeamsService` implementation.
 4. Start or restart the server.
 
----
+The plugin itself contains no game logic. It only bootstraps the Bukkit
+`ServicesManager` bridge, so no configuration file is needed.
 
-## For providers (team plugins)
+### Verifying the installation
+
+When the server starts, any registered team plugin will log that it has
+registered its services. If no team plugin is installed, consumers will receive
+an empty `Optional` or `null` from the API and must handle that gracefully.
+
+## For consumers
+
+Consumers are plugins that read or react to team data. They depend on
+`teams-api` but do not implement any service interfaces.
 
 ### 1. Add the dependency
 
@@ -74,9 +83,13 @@ from the team plugin directly. Providers register and unregister themselves via
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
+    <scope>provided</scope>
 </dependency>
 ```
+
+Use `<scope>provided</scope>` because `teams-api` classes are supplied by the
+`TeamsAPI.jar` on the server at runtime.
 
 **Gradle**:
 
@@ -85,108 +98,9 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.1.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.2.0'
 }
 ```
-
-### 2. Implement `TeamsService`
-
-```java
-public class MyTeamsService implements TeamsService {
-
-    @Override
-    public Optional<Team> createTeam(String name, UUID ownerUUID) {
-        // Fire TeamCreateEvent before persisting
-        // Return empty Optional if event is cancelled or name is taken
-    }
-
-    @Override
-    public Optional<Team> getPlayerTeam(UUID playerUUID) {
-        // Return the team this player belongs to
-    }
-
-    // ... implement all interface methods
-}
-```
-
-### 3. Register and unregister
-
-```java
-private MyTeamsService teamsService;
-
-@Override
-public void onEnable() {
-    teamsService = new MyTeamsService(this);
-    TeamsAPI.registerProvider(this, teamsService);
-}
-
-@Override
-public void onDisable() {
-    TeamsAPI.unregisterProvider(teamsService);
-}
-```
-
-### 4. Optionally implement `TeamsInviteService`
-
-If your plugin supports team invitations, implement and register `TeamsInviteService`
-alongside `TeamsService`:
-
-```java
-public class MyInviteService implements TeamsInviteService {
-
-    @Override
-    public boolean invitePlayer(UUID teamId, UUID inviterUUID, UUID inviteeUUID) {
-        // Fire TeamInviteEvent first; return false if cancelled
-    }
-
-    @Override
-    public Optional<Team> acceptInvite(UUID teamId, UUID playerUUID) {
-        // Add player, fire TeamInviteAcceptEvent, return the team
-    }
-
-    @Override
-    public boolean declineInvite(UUID teamId, UUID playerUUID) {
-        // Remove pending invite, fire TeamInviteDeclineEvent
-    }
-}
-```
-
-Register and unregister it alongside `TeamsService`:
-
-```java
-private MyTeamsService teamsService;
-private MyInviteService inviteService;
-
-@Override
-public void onEnable() {
-    teamsService = new MyTeamsService(this);
-    inviteService = new MyInviteService(this);
-    TeamsAPI.registerProvider(this, teamsService);
-    TeamsAPI.registerInviteProvider(this, inviteService);
-}
-
-@Override
-public void onDisable() {
-    TeamsAPI.unregisterProvider(teamsService);
-    TeamsAPI.unregisterInviteProvider(inviteService);
-}
-```
-
-### 5. Declare the soft-dependency in `plugin.yml`
-
-```yaml
-softdepend:
-  - TeamsAPI
-```
-
----
-
-## For consumers (plugins using team data)
-
-### 1. Add the dependency (same as providers above)
-
-Use `scope: provided` in Maven or `compileOnly` in Gradle since `teams-api`
-classes are provided by the `TeamsAPI.jar` installed on the server.
 
 ### 2. Declare the dependency in `plugin.yml`
 
@@ -195,21 +109,22 @@ depend:
   - TeamsAPI
 ```
 
-If team support is optional in your plugin, use `softdepend` instead.
+If team support is optional in your plugin, use `softdepend` instead. In that
+case, always guard your API calls with `TeamsAPI.isAvailable()`.
 
-### 3. Use the API
+### 3. Use the team service
 
 ```java
 @Override
 public void onEnable() {
     if (!TeamsAPI.isAvailable()) {
-        getLogger().warning("No team plugin found — team features disabled.");
+        getLogger().warning("No team plugin found. Team features disabled.");
         return;
     }
-    getLogger().info("TeamsAPI found: team features enabled.");
+    getLogger().info("TeamsAPI found. Team features enabled.");
 }
 
-// Later, in a command or listener:
+// In a command or listener:
 private void handlePlayerCommand(Player player) {
     TeamsService teams = TeamsAPI.getService();
     if (teams == null) {
@@ -228,7 +143,11 @@ private void handlePlayerCommand(Player player) {
 }
 ```
 
-If your plugin also wants to send invitations, check for `TeamsInviteService`:
+### 4. Use the invite service (optional)
+
+The invite service is registered separately from the core service. Always check
+`TeamsAPI.isInviteAvailable()` before using it, as not every team plugin
+implements invitations.
 
 ```java
 private void handleInviteCommand(Player sender, Player target, UUID teamId) {
@@ -242,39 +161,70 @@ private void handleInviteCommand(Player sender, Player target, UUID teamId) {
 }
 ```
 
----
+### 5. Use the warp service (optional)
+
+The warp service is registered separately from the core service. Always check
+`TeamsAPI.isWarpAvailable()` before using it, as not every team plugin
+implements warps.
+
+```java
+private void handleWarpCommand(Player player, UUID teamId, String warpName) {
+    if (!TeamsAPI.isWarpAvailable()) {
+        player.sendMessage("The active team plugin does not support warps.");
+        return;
+    }
+    TeamsWarpService warps = TeamsAPI.getWarpService();
+    warps.getWarp(teamId, warpName).ifPresentOrElse(
+        warp -> player.teleport(warp.getLocation()),
+        () -> player.sendMessage("Warp '" + warpName + "' does not exist.")
+    );
+}
+```
 
 ## Events
 
-**Core events** — providers are **encouraged** to fire these; whether they do is implementation-specific.
+Providers are encouraged to fire events before performing state changes. Whether
+they actually do so is implementation-specific; do not rely on events for
+critical logic.
 
-| Event                  | When fired                          | Cancellable |
-|------------------------|-------------------------------------|-------------|
-| `TeamCreateEvent`      | Before a team is created            | Yes         |
-| `TeamDeleteEvent`      | Before a team is deleted            | Yes         |
-| `TeamJoinEvent`        | Before a player joins a team        | Yes         |
-| `TeamLeaveEvent`       | Before a player leaves a team       | Yes         |
-| `TeamRoleChangeEvent`  | Before a member's role changes      | Yes         |
+### Core events
 
-**Invite events** — fired by providers that implement `TeamsInviteService`.
+All core events are cancellable.
 
-| Event                    | When fired                                 | Cancellable |
-|--------------------------|--------------------------------------------|-------------|
-| `TeamInviteEvent`        | Before an invitation is recorded           | Yes         |
-| `TeamInviteAcceptEvent`  | After the player has joined the team       | No          |
-| `TeamInviteDeclineEvent` | After the pending invitation was removed   | No          |
+| Event | When fired |
+|-------|------------|
+| `TeamCreateEvent` | Before a team is created |
+| `TeamDeleteEvent` | Before a team is deleted |
+| `TeamJoinEvent` | Before a player joins a team |
+| `TeamLeaveEvent` | Before a player leaves a team |
+| `TeamRoleChangeEvent` | Before a member's role changes |
 
-Example listeners:
+### Invite events
+
+Fired by providers that implement `TeamsInviteService`.
+
+| Event | Cancellable | When fired |
+|-------|-------------|------------|
+| `TeamInviteEvent` | Yes | Before an invitation is recorded |
+| `TeamInviteAcceptEvent` | No | After the player has joined the team |
+| `TeamInviteDeclineEvent` | No | After the pending invitation was removed |
+
+### Warp events
+
+Fired by providers that implement `TeamsWarpService`.
+
+| Event | Cancellable | When fired |
+|-------|-------------|------------|
+| `TeamWarpSetEvent` | Yes | Before a warp is created or updated |
+| `TeamWarpDeleteEvent` | Yes | Before a warp is removed |
+
+### Example listeners
 
 ```java
 @EventHandler
 public void onTeamJoin(TeamJoinEvent event) {
-    Team team = event.getTeam();
-    UUID player = event.getPlayerUUID();
-
-    if (team.getSize() >= 10) {
+    if (event.getTeam().getSize() >= 10) {
         event.setCancelled(true);
-        // Notify player that the team is full
     }
 }
 
@@ -284,12 +234,10 @@ public void onInvite(TeamInviteEvent event) {
 }
 
 @EventHandler
-public void onInviteAccepted(TeamInviteAcceptEvent event) {
-    // Informational — player has already joined
+public void onWarpSet(TeamWarpSetEvent event) {
+    // Cancel to prevent the warp from being saved
 }
 ```
-
----
 
 ## API versioning
 
@@ -297,16 +245,18 @@ Check `TeamsAPI.API_VERSION` at runtime if you need to guard against future
 breaking changes:
 
 ```java
-String version = TeamsAPI.API_VERSION; // e.g. "1.0.0"
+String version = TeamsAPI.API_VERSION; // e.g. "1.2.0"
 ```
 
-TeamsAPI follows Semantic Versioning. A major version bump indicates breaking
-changes in `TeamsService` or the model interfaces.
+TeamsAPI follows Semantic Versioning. A major version bump signals breaking
+changes in `TeamsService` or the model interfaces. Minor bumps add optional,
+backward-compatible features. Patch bumps are bug fixes only.
 
----
+## See also
 
-## See Also
-
-- [API Reference](./api.md) — interface and model overview
+- [Team Provider](provider-teams): implementing `TeamsService` in your team plugin
+- [Invite Provider](provider-invites): implementing `TeamsInviteService` for invitation support
+- [Warp Provider](provider-warps): implementing `TeamsWarpService` for warp support
+- [API Reference](api): interface and model overview
 - [GitHub repository](https://github.com/ez-plugins/teams-api)
 - [Jitpack page](https://jitpack.io/#ez-plugins/teams-api)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,33 +2,33 @@
 layout: home
 title: TeamsAPI
 nav_order: 1
-description: "Universal Teams API for Minecraft — Vault-style bridge between team plugins and consumers"
+description: "Universal Teams API for Minecraft. Vault-style bridge between team plugins and consumers."
 permalink: /
 ---
 
 # TeamsAPI
 
 [![JitPack](https://jitpack.io/v/ez-plugins/teams-api.svg)](https://jitpack.io/#ez-plugins/teams-api)
-[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-1.0.1-blue?logo=github)](https://github.com/ez-plugins/teams-api/packages)
+[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-1.2.0-blue?logo=github)](https://github.com/ez-plugins/teams-api/packages)
 
 **TeamsAPI** is a passive bridge plugin for Paper 26.1+ servers, modelled on
 [Vault](https://github.com/MilkBowl/VaultAPI). It defines a standard interface
 for team operations so any plugin needing team data can work with any compatible
-team plugin — without coupling them together.
-
----
+team plugin without coupling them together.
 
 ## Features
 
-- **Provider-agnostic** — any team plugin can register as the `TeamsService` provider
-- **Vault-style facade** — single static `TeamsAPI.getService()` entry point
-- **Bukkit ServicesManager** — standard service priority system supported
-- **Optional-safe API** — all lookups return `Optional<T>`, never `null`
-- **Null-safe facade** — `TeamsAPI` methods silently handle `null` arguments
-- **5 cancellable events** — `TeamCreateEvent`, `TeamDeleteEvent`, `TeamJoinEvent`,
+- **Provider-agnostic**: any team plugin can register as the `TeamsService` provider
+- **Vault-style facade**: single static `TeamsAPI.getService()` entry point
+- **ServicesManager integration**: Bukkit's standard service priority system is fully supported
+- **Optional-safe API**: all lookups return `Optional<T>`, never `null`
+- **Null-safe facade**: `TeamsAPI` static methods silently handle `null` arguments
+- **5 cancellable core events**: `TeamCreateEvent`, `TeamDeleteEvent`, `TeamJoinEvent`,
   `TeamLeaveEvent`, `TeamRoleChangeEvent`
-
----
+- **Optional invite support**: register a `TeamsInviteService` to handle invitation flows
+  independently of the core team service
+- **Optional warp support**: register a `TeamsWarpService` to manage named team warps
+  independently of the core team service
 
 ## Quick start
 
@@ -45,7 +45,7 @@ team plugin — without coupling them together.
 <dependency>
   <groupId>com.github.ez-plugins</groupId>
   <artifactId>teams-api</artifactId>
-  <version>1.0.1</version>
+  <version>1.2.0</version>
   <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ team plugin — without coupling them together.
 @Override
 public void onEnable() {
     if (!TeamsAPI.isAvailable()) {
-        getLogger().warning("No team plugin found — team features disabled.");
+        getLogger().warning("No team plugin found. Team features disabled.");
         return;
     }
     TeamsService teams = TeamsAPI.getService();
@@ -64,16 +64,15 @@ public void onEnable() {
 }
 ```
 
----
-
 ## Documentation
 
 | Page | What it covers |
 |------|----------------|
-| [Developer Guide](developer-guide) | Provider and consumer integration guide |
+| [Developer Guide](developer-guide) | Architecture, installation, and consumer usage |
+| [Team Provider](provider-teams) | Implementing `TeamsService` in your team plugin |
+| [Invite Provider](provider-invites) | Implementing `TeamsInviteService` for invitation support |
+| [Warp Provider](provider-warps) | Implementing `TeamsWarpService` for warp support |
 | [API Reference](api) | Full public-method tables for every class |
-
----
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ public void onEnable() {
 
 | Page | What it covers |
 |------|----------------|
+| [Server Guide](server-guide) | Installation, verification, and troubleshooting for server owners |
 | [Developer Guide](developer-guide) | Architecture, installation, and consumer usage |
 | [Team Provider](provider-teams) | Implementing `TeamsService` in your team plugin |
 | [Invite Provider](provider-invites) | Implementing `TeamsInviteService` for invitation support |

--- a/docs/provider-invites.md
+++ b/docs/provider-invites.md
@@ -1,0 +1,103 @@
+---
+title: Invite Provider
+nav_order: 2
+parent: Developer Guide
+description: "How to implement and register TeamsInviteService for invitation support"
+---
+
+# Invite Provider
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+`TeamsInviteService` is an optional extension for team invitation flows. It is
+registered independently of `TeamsService`, and consumers check
+`TeamsAPI.isInviteAvailable()` before using it. You can implement it alongside
+`TeamsService` or ship it in a separate plugin.
+
+## 1. Implement `TeamsInviteService`
+
+```java
+public class MyInviteService implements TeamsInviteService {
+
+    @Override
+    public boolean invitePlayer(UUID teamId, UUID inviterUUID, UUID inviteeUUID) {
+        // Fire TeamInviteEvent first.
+        // Return false if the event is cancelled or a pending invite already exists.
+    }
+
+    @Override
+    public Optional<Team> acceptInvite(UUID teamId, UUID playerUUID) {
+        // Add the player to the team as MEMBER.
+        // Fire TeamInviteAcceptEvent after a successful join.
+        // Return an empty Optional if no invite exists or the join failed.
+    }
+
+    @Override
+    public boolean declineInvite(UUID teamId, UUID playerUUID) {
+        // Remove the pending invite record.
+        // Fire TeamInviteDeclineEvent after removal.
+        // Return false if no invite existed.
+    }
+}
+```
+
+### Event firing guidelines
+
+| Event | Cancellable | When to fire |
+|-------|-------------|--------------|
+| `TeamInviteEvent` | Yes | Before recording the invite |
+| `TeamInviteAcceptEvent` | No | After the player has joined the team |
+| `TeamInviteDeclineEvent` | No | After the invite record is removed |
+
+`TeamInviteEvent` is cancellable. If cancelled, do not record the invite and
+return `false` from `invitePlayer`.
+
+`TeamInviteAcceptEvent` and `TeamInviteDeclineEvent` are informational. Fire
+them after the state change has already been committed.
+
+## 2. Register and unregister
+
+Register and unregister the invite service alongside the core team service.
+
+```java
+private MyTeamsService teamsService;
+private MyInviteService inviteService;
+
+@Override
+public void onEnable() {
+    teamsService = new MyTeamsService(this);
+    inviteService = new MyInviteService(this);
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerInviteProvider(this, inviteService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterInviteProvider(inviteService);
+}
+```
+
+To register at a specific priority:
+
+```java
+TeamsAPI.registerInviteProvider(this, inviteService, ServicePriority.High);
+```
+
+## 3. Declare the soft-dependency in `plugin.yml`
+
+```yaml
+softdepend:
+  - TeamsAPI
+```
+
+## See also
+
+- [Team Provider](../provider-teams): implementing the core `TeamsService`
+- [Warp Provider](../provider-warps): adding optional warp support
+- [API Reference](../api): full interface and model documentation

--- a/docs/provider-teams.md
+++ b/docs/provider-teams.md
@@ -1,0 +1,177 @@
+---
+title: Team Provider
+nav_order: 1
+parent: Developer Guide
+description: "How to implement and register TeamsService in your team plugin"
+---
+
+# Team Provider
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+This page is for developers building a team plugin that wants to expose its data
+through TeamsAPI. Implementing `TeamsService` and registering it with the API
+lets any consumer plugin access your team data without importing your classes
+directly.
+
+## 1. Add the dependency
+
+**Maven** (via Jitpack):
+
+```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+
+<dependency>
+    <groupId>com.github.ez-plugins</groupId>
+    <artifactId>teams-api</artifactId>
+    <version>1.2.0</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+**Gradle**:
+
+```groovy
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+dependencies {
+    compileOnly 'com.github.ez-plugins:teams-api:1.2.0'
+}
+```
+
+The `provided`/`compileOnly` scope is correct because `TeamsAPI.jar` on the
+server supplies the interface classes at runtime.
+
+## 2. Implement `TeamsService`
+
+Create a class that implements every method in `TeamsService`. The interface
+covers team lifecycle, lookup, and membership operations.
+
+```java
+public class MyTeamsService implements TeamsService {
+
+    @Override
+    public Optional<Team> createTeam(String name, UUID ownerUUID) {
+        // Fire TeamCreateEvent before persisting.
+        // Return an empty Optional if the event is cancelled or the name is taken.
+    }
+
+    @Override
+    public boolean deleteTeam(UUID teamId) {
+        // Fire TeamDeleteEvent before removing.
+        // Return false if no team with that ID exists.
+    }
+
+    @Override
+    public Optional<Team> getPlayerTeam(UUID playerUUID) {
+        // Return the team this player currently belongs to.
+    }
+
+    // Implement all remaining interface methods.
+}
+```
+
+Refer to the [API Reference](../api#teamsservice-interface) for the full list of
+methods you must implement.
+
+### Event firing guidelines
+
+Providers are encouraged to fire core events before making state changes.
+
+| Event | Fire before |
+|-------|-------------|
+| `TeamCreateEvent` | Persisting the new team |
+| `TeamDeleteEvent` | Removing the team |
+| `TeamJoinEvent` | Adding a member |
+| `TeamLeaveEvent` | Removing a member |
+| `TeamRoleChangeEvent` | Updating a member's role |
+
+All core events are cancellable. If an event is cancelled, discard the operation
+and return the appropriate failure value (`false` or an empty `Optional`).
+
+## 3. Implement `Team` and `TeamMember`
+
+Your `TeamsService` methods return `Team` and `TeamMember` objects. These are
+interfaces defined in `teams-api`; you must supply your own implementations.
+
+```java
+public class MyTeam implements Team {
+
+    private final UUID id;
+    private final String name;
+    // ... other fields
+
+    @Override
+    public UUID getId() { return id; }
+
+    @Override
+    public String getName() { return name; }
+
+    @Override
+    public Collection<TeamMember> getMembers() {
+        // Return a snapshot, not a live mutable collection.
+    }
+
+    // Implement all remaining interface methods.
+}
+```
+
+Return read-only snapshots. Do not expose mutable internal state through these
+interfaces.
+
+## 4. Register and unregister
+
+Register in `onEnable` and unregister in `onDisable`. Failing to unregister can
+leave a stale provider in the `ServicesManager`.
+
+```java
+private MyTeamsService teamsService;
+
+@Override
+public void onEnable() {
+    teamsService = new MyTeamsService(this);
+    TeamsAPI.registerProvider(this, teamsService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+}
+```
+
+To register at a specific priority:
+
+```java
+TeamsAPI.registerProvider(this, teamsService, ServicePriority.High);
+```
+
+When multiple providers are registered, Bukkit's `ServicesManager` selects the
+one with the highest priority. `ServicePriority.Normal` is the default.
+
+## 5. Declare the soft-dependency in `plugin.yml`
+
+```yaml
+softdepend:
+  - TeamsAPI
+```
+
+`softdepend` is sufficient because the provider registers itself at startup.
+TeamsAPI does not need to be present for your plugin to load; it only needs to
+exist before registration is attempted.
+
+## See also
+
+- [Invite Provider](../provider-invites): adding optional invitation support
+- [Warp Provider](../provider-warps): adding optional warp support
+- [API Reference](../api): full interface and model documentation

--- a/docs/provider-warps.md
+++ b/docs/provider-warps.md
@@ -1,0 +1,147 @@
+---
+title: Warp Provider
+nav_order: 3
+parent: Developer Guide
+description: "How to implement and register TeamsWarpService for team warp support"
+---
+
+# Warp Provider
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+`TeamsWarpService` is an optional extension for managing named warp points
+belonging to teams. It is registered independently of `TeamsService`, and
+consumers check `TeamsAPI.isWarpAvailable()` before using it.
+
+## 1. Implement `TeamsWarpService`
+
+```java
+public class MyWarpService implements TeamsWarpService {
+
+    @Override
+    public boolean setWarp(UUID teamId, String name, Location location, UUID creatorUUID) {
+        // Fire TeamWarpSetEvent first.
+        // Create or overwrite the named warp.
+        // Return false if the event is cancelled or the team does not exist.
+    }
+
+    @Override
+    public boolean removeWarp(UUID teamId, String name) {
+        // Fire TeamWarpDeleteEvent first.
+        // Remove the warp record.
+        // Return false if the event is cancelled or no such warp exists.
+    }
+
+    @Override
+    public Optional<TeamWarp> getWarp(UUID teamId, String name) {
+        // Return a read-only snapshot, or empty if the warp does not exist.
+    }
+
+    @Override
+    public Collection<TeamWarp> getWarps(UUID teamId) {
+        // Return an unmodifiable collection of all warps for the team.
+        // Return an empty collection if the team has no warps or does not exist.
+    }
+}
+```
+
+### Event firing guidelines
+
+| Event | Cancellable | When to fire |
+|-------|-------------|--------------|
+| `TeamWarpSetEvent` | Yes | Before creating or updating a warp |
+| `TeamWarpDeleteEvent` | Yes | Before removing a warp |
+
+Both events are cancellable. If cancelled, do not modify storage and return
+`false` from the corresponding method.
+
+## 2. Implement `TeamWarp`
+
+Your `getWarp` and `getWarps` methods return `TeamWarp` objects. This is an
+interface defined in `teams-api`; you must supply your own implementation.
+
+```java
+public class MyTeamWarp implements TeamWarp {
+
+    private final UUID teamId;
+    private final String name;
+    private final Location location;
+    private final UUID creatorUUID;
+    private final Instant createdAt;
+
+    @Override
+    public UUID getTeamId() { return teamId; }
+
+    @Override
+    public String getName() { return name; }
+
+    @Override
+    public Location getLocation() { return location; }
+
+    @Override
+    public UUID getCreatorUUID() { return creatorUUID; }
+
+    @Override
+    public Instant getCreatedAt() { return createdAt; }
+}
+```
+
+Return read-only snapshots. Do not expose mutable internal warp state through
+this interface.
+
+If your implementation does not track creation time, return `Instant.EPOCH` as
+a sentinel value, as documented in the interface contract.
+
+### Warp name uniqueness
+
+Warp names are unique within a team. The `setWarp` method should overwrite an
+existing warp if one with the same name already exists for that team, or create
+a new one if it does not. Case-sensitivity of warp names is
+implementation-defined; document your chosen behaviour clearly for consumers.
+
+## 3. Register and unregister
+
+Register and unregister the warp service alongside the core team service.
+
+```java
+private MyTeamsService teamsService;
+private MyWarpService warpService;
+
+@Override
+public void onEnable() {
+    teamsService = new MyTeamsService(this);
+    warpService = new MyWarpService(this);
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerWarpProvider(this, warpService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterWarpProvider(warpService);
+}
+```
+
+To register at a specific priority:
+
+```java
+TeamsAPI.registerWarpProvider(this, warpService, ServicePriority.High);
+```
+
+## 4. Declare the soft-dependency in `plugin.yml`
+
+```yaml
+softdepend:
+  - TeamsAPI
+```
+
+## See also
+
+- [Team Provider](../provider-teams): implementing the core `TeamsService`
+- [Invite Provider](../provider-invites): adding optional invitation support
+- [API Reference](../api): full interface and model documentation

--- a/docs/server-guide.md
+++ b/docs/server-guide.md
@@ -1,0 +1,176 @@
+---
+title: Server Guide
+nav_order: 2
+description: "Installation and setup guide for server owners running TeamsAPI"
+---
+
+# Server Guide
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+TeamsAPI is a **bridge plugin**. On its own it does nothing visible to players.
+It installs a common interface that your team plugin and other plugins can use to
+talk to each other, so you do not need to install separate compatibility add-ons
+for every combination of plugins.
+
+Think of it like Vault: install it once, then any plugin that reads economy or
+permissions data will automatically work with whichever economy or permission
+plugin you choose.
+
+## Requirements
+
+| Requirement | Version |
+|-------------|---------|
+| Java | **25** or newer |
+| Server software | **Paper 26.1** or a fork compatible with Paper's plugin API |
+| Team plugin | Any plugin that registers a `TeamsService` provider |
+
+TeamsAPI does **not** work on vanilla Spigot. Paper (or a Paper fork such as
+Purpur) is required.
+
+## Installation
+
+### Step 1: Download TeamsAPI
+
+Download the latest `teams-api-plugin-VERSION.jar` from the
+[Releases page](https://github.com/ez-plugins/teams-api/releases).
+
+Make sure you download the **plugin JAR** (`teams-api-plugin-*.jar`), not the
+API artifact (`teams-api-*.jar`). The API artifact is for developers only.
+
+### Step 2: Place the JAR in your plugins folder
+
+Copy `teams-api-plugin-VERSION.jar` into your server's `plugins/` directory.
+
+```
+your-server/
+  plugins/
+    teams-api-plugin-1.2.0.jar   <-- add this
+    YourTeamPlugin.jar
+    ...
+```
+
+### Step 3: Install a compatible team plugin
+
+TeamsAPI needs a team plugin that registers itself as a provider. Without one,
+TeamsAPI loads successfully but has no data to serve. Check the documentation
+of your team plugin to confirm it supports TeamsAPI.
+
+### Step 4: (Re)start the server
+
+Restart the server. TeamsAPI loads before your team plugin finishes enabling
+(because team plugins declare `softdepend: TeamsAPI`), so no special startup
+order is required.
+
+## Verifying the installation
+
+Look for log messages from your team plugin confirming that it has registered
+with TeamsAPI. The exact wording depends on the team plugin, but you should see
+something like:
+
+```
+[YourTeamPlugin] Registered TeamsService with TeamsAPI.
+```
+
+If you see no such message and other plugins report that team features are
+unavailable, check the troubleshooting section below.
+
+You can also check which plugins are installed and enabled from the server
+console:
+
+```
+/plugins
+```
+
+Both `TeamsAPI` and your team plugin should appear green in the list.
+
+## Optional services
+
+Some team plugins register additional optional services beyond the core team
+service:
+
+| Service | What it provides |
+|---------|-----------------|
+| `TeamsInviteService` | Sending, accepting, and declining team invitations |
+| `TeamsWarpService` | Creating and teleporting to named team warps |
+
+These are independent of the core service. A plugin that reads warp data checks
+whether a warp provider is registered and reports that warps are unsupported if
+none is found. No configuration is required on your end; it is entirely up to
+your team plugin whether it registers these services.
+
+## Updating TeamsAPI
+
+1. Stop the server.
+2. Delete the old `teams-api-plugin-*.jar` from `plugins/`.
+3. Place the new JAR in `plugins/`.
+4. Start the server.
+
+TeamsAPI has no configuration files and no stored data, so there is nothing to
+migrate between versions.
+
+Patch and minor version updates (for example 1.1.0 to 1.2.0) are always
+backward-compatible. Existing team plugins and consumer plugins do not need to
+be updated when you update TeamsAPI unless their own documentation says
+otherwise.
+
+## Troubleshooting
+
+### TeamsAPI loads but no team features work
+
+Your team plugin has not registered a provider. Possible causes:
+
+- The team plugin does not support TeamsAPI. Check its documentation.
+- The team plugin failed to enable. Check the server log for errors from that
+  plugin.
+- The team plugin registered at a later stage than expected. If the team plugin
+  uses `Bukkit.getScheduler().runTaskLater(...)` to register, some consumer
+  plugins may check availability before registration is complete. This is a bug
+  in the team plugin, not in TeamsAPI.
+
+### Invite or warp features are reported as unavailable
+
+Not every team plugin implements `TeamsInviteService` or `TeamsWarpService`.
+Check the documentation of your team plugin to see which services it registers.
+
+### Two team plugins are installed
+
+If two plugins both register as team providers, Bukkit's `ServicesManager` picks
+the one with the higher priority. The active provider is the one returned by
+`TeamsAPI.getService()`. Running two team plugins simultaneously is not a
+supported configuration and may cause conflicts.
+
+### Plugin version mismatch warnings
+
+If a consumer plugin logs a warning about the API version, it was compiled
+against a different version of TeamsAPI than the one installed. As long as the
+major version number matches (for example, both are `1.x.x`), the plugins are
+compatible. If the major version differs, you may need to update either TeamsAPI
+or the consumer plugin.
+
+## Frequently asked questions
+
+**Do I need TeamsAPI if my team plugin already works?**
+
+Only if another plugin you are installing requires it. TeamsAPI is a dependency,
+not a standalone feature plugin.
+
+**Can I use TeamsAPI without a team plugin?**
+
+Yes. TeamsAPI will load and run without a team plugin present. Plugins that
+depend on it will simply report that no team provider is available and disable
+their team-related features.
+
+**Does TeamsAPI add any commands or permissions?**
+
+No. TeamsAPI has no player-facing commands, no permissions, and no configuration
+file.
+
+**Where is the config file?**
+
+There is no config file. TeamsAPI requires no configuration.

--- a/docs/server-guide.md
+++ b/docs/server-guide.md
@@ -47,7 +47,7 @@ API artifact (`teams-api-*.jar`). The API artifact is for developers only.
 
 Copy `teams-api-plugin-VERSION.jar` into your server's `plugins/` directory.
 
-```
+```text
 your-server/
   plugins/
     teams-api-plugin-1.2.0.jar   <-- add this
@@ -73,7 +73,7 @@ Look for log messages from your team plugin confirming that it has registered
 with TeamsAPI. The exact wording depends on the team plugin, but you should see
 something like:
 
-```
+```text
 [YourTeamPlugin] Registered TeamsService with TeamsAPI.
 ```
 
@@ -83,7 +83,7 @@ unavailable, check the troubleshooting section below.
 You can also check which plugins are installed and enabled from the server
 console:
 
-```
+```text
 /plugins
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- Allow CI to override Paper API version via -Dpaper.version -->
         <paper.version>26.1.2.build.57-stable</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
-        <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
+        <mockbukkit.artifactId>mockbukkit-v26.1.2</mockbukkit.artifactId>
         <mockbukkit.version>0.0.0-unset</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <maven.compiler.target>25</maven.compiler.target>
         <maven.compiler.release>25</maven.compiler.release>
         <!-- Allow CI to override Paper API version via -Dpaper.version -->
-        <paper.version>26.1.2.build.57-stable</paper.version>
+        <paper.version>26.1.1.build.17-alpha</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
         <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
-        <mockbukkit.version>dev-7fba375</mockbukkit.version>
+        <mockbukkit.version>dev-d245e0a</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <paper.version>26.1.2.build.57-stable</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
         <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
-        <mockbukkit.version>ci-local</mockbukkit.version>
+        <mockbukkit.version>0.0.0-unset</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <maven.compiler.target>25</maven.compiler.target>
         <maven.compiler.release>25</maven.compiler.release>
         <!-- Allow CI to override Paper API version via -Dpaper.version -->
-        <paper.version>26.1.1.build.17-alpha</paper.version>
+        <paper.version>26.1.2.build.57-stable</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
         <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
-        <mockbukkit.version>dev-d245e0a</mockbukkit.version>
+        <mockbukkit.version>dev-7fba375</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft — bridges team plugins with a clean, timeless interface.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <paper.version>26.1.2.build.57-stable</paper.version>
         <mockbukkit.groupId>org.mockbukkit.mockbukkit</mockbukkit.groupId>
         <mockbukkit.artifactId>mockbukkit-v26.1</mockbukkit.artifactId>
-        <mockbukkit.version>dev-7fba375</mockbukkit.version>
+        <mockbukkit.version>ci-local</mockbukkit.version>
         <junit.jupiter.version>6.0.3</junit.jupiter.version>
         <mockito.version>5.23.0</mockito.version>
         <checkstyle.version>10.21.4</checkstyle.version>

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -243,4 +243,99 @@ public final class TeamsAPI {
 
         Bukkit.getServicesManager().unregister(TeamsInviteService.class, provider);
     }
+
+    // -------------------------------------------------------------------------
+    // Warp provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsWarpService} provider, or {@code null}
+     * if no warp provider has been registered.
+     *
+     * <p>Consumers should check {@link #isWarpAvailable()} before calling this method
+     * to handle gracefully the case where no team plugin supports warps.</p>
+     *
+     * @return the active {@link TeamsWarpService}, or {@code null} if unavailable
+     */
+    public static TeamsWarpService getWarpService() {
+        try {
+            final RegisteredServiceProvider<TeamsWarpService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsWarpService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsWarpService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if a warp provider is available, {@code false} otherwise
+     */
+    public static boolean isWarpAvailable() {
+        return getWarpService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsWarpService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsWarpService} implementation; must not be {@code null}
+     */
+    public static void registerWarpProvider(final Plugin plugin,
+            final TeamsWarpService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsWarpService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsWarpService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsWarpService} implementation; must not be {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerWarpProvider(
+            final Plugin plugin,
+            final TeamsWarpService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsWarpService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsWarpService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsWarpService} provider to unregister; may be {@code null}
+     */
+    public static void unregisterWarpProvider(final TeamsWarpService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsWarpService.class, provider);
+    }
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -45,7 +45,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.1.0";
+    public static final String API_VERSION = "1.2.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsWarpService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsWarpService.java
@@ -1,0 +1,91 @@
+package com.skyblockexp.teamsapi.api;
+
+import com.skyblockexp.teamsapi.model.TeamWarp;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Location;
+
+/**
+ * Optional extension service for team warp management.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to support
+ * warps register an implementation separately via
+ * {@link TeamsAPI#registerWarpProvider(org.bukkit.plugin.Plugin, TeamsWarpService)}.
+ * Consumers first check whether the service is available with
+ * {@link TeamsAPI#isWarpAvailable()} before calling {@link TeamsAPI#getWarpService()}.</p>
+ *
+ * <p>Existing {@link TeamsService} implementations are not required to implement this
+ * interface; omitting it is a supported configuration and the API will degrade gracefully.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // In your team plugin's onEnable():
+ * TeamsAPI.registerWarpProvider(this, new MyWarpServiceImpl());
+ *
+ * // In your team plugin's onDisable():
+ * TeamsAPI.unregisterWarpProvider(myWarpService);
+ * }</pre>
+ *
+ * <p><strong>Consumer usage example:</strong></p>
+ * <pre>{@code
+ * TeamsWarpService warps = TeamsAPI.getWarpService();
+ * if (warps == null) {
+ *     player.sendMessage("Warps are not supported by the active team plugin.");
+ *     return;
+ * }
+ * warps.getWarp(teamId, "home").ifPresent(w -> player.teleport(w.getLocation()));
+ * }</pre>
+ */
+public interface TeamsWarpService {
+
+    /**
+     * Creates or updates a named warp for the given team at the given location.
+     *
+     * <p>Providers should fire {@link com.skyblockexp.teamsapi.event.TeamWarpSetEvent}
+     * before recording the warp. If the event is cancelled, implementations should
+     * return {@code false}.</p>
+     *
+     * @param teamId      the UUID of the team; must not be {@code null}
+     * @param name        the name to assign to this warp; must not be {@code null}
+     * @param location    the {@link Location} the warp points to; must not be {@code null}
+     * @param creatorUUID the UUID of the player setting the warp; must not be {@code null}
+     * @return {@code true} if the warp was successfully created or updated,
+     *         {@code false} otherwise (e.g. the team does not exist or the event was cancelled)
+     */
+    boolean setWarp(UUID teamId, String name, Location location, UUID creatorUUID);
+
+    /**
+     * Removes the named warp from the given team.
+     *
+     * <p>Providers should fire {@link com.skyblockexp.teamsapi.event.TeamWarpDeleteEvent}
+     * before removing the warp. If the event is cancelled, implementations should
+     * return {@code false}.</p>
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @param name   the name of the warp to remove; must not be {@code null}
+     * @return {@code true} if the warp existed and was removed, {@code false} otherwise
+     */
+    boolean removeWarp(UUID teamId, String name);
+
+    /**
+     * Retrieves the named warp for the given team.
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @param name   the name of the warp; must not be {@code null}
+     * @return an {@link Optional} containing the {@link TeamWarp}, or empty if no
+     *         warp with that name exists for the team
+     */
+    Optional<TeamWarp> getWarp(UUID teamId, String name);
+
+    /**
+     * Returns all warps registered for the given team.
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return an unmodifiable collection of {@link TeamWarp}s; never {@code null},
+     *         empty if the team has no warps or does not exist
+     */
+    Collection<TeamWarp> getWarps(UUID teamId);
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamWarpDeleteEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamWarpDeleteEvent.java
@@ -1,0 +1,79 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a team warp is about to be deleted.
+ *
+ * <p>Providers should fire this event before removing the warp. If the event is
+ * cancelled, the warp must not be removed and
+ * {@link com.skyblockexp.teamsapi.api.TeamsWarpService#removeWarp} should return
+ * {@code false}.</p>
+ */
+public class TeamWarpDeleteEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The name of the warp being deleted. */
+    private final String name;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamWarpDeleteEvent}.
+     *
+     * @param team the team whose warp is being deleted; must not be {@code null}
+     * @param name the name of the warp being deleted; must not be {@code null}
+     */
+    public TeamWarpDeleteEvent(final Team team, final String name) {
+        super(team);
+        this.name = name;
+    }
+
+    /**
+     * Returns the name of the warp being deleted.
+     *
+     * @return the warp name; never {@code null}
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamWarpSetEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamWarpSetEvent.java
@@ -1,0 +1,114 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a team warp is about to be created or updated.
+ *
+ * <p>Providers should fire this event before persisting the warp. If the event is
+ * cancelled, the warp must not be set and
+ * {@link com.skyblockexp.teamsapi.api.TeamsWarpService#setWarp} should return
+ * {@code false}.</p>
+ */
+public class TeamWarpSetEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The name of the warp being set. */
+    private final String name;
+
+    /** The location the warp points to. */
+    private final Location location;
+
+    /** The UUID of the player who is setting the warp. */
+    private final UUID creatorUUID;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamWarpSetEvent}.
+     *
+     * @param team        the team whose warp is being set; must not be {@code null}
+     * @param name        the name of the warp being set; must not be {@code null}
+     * @param location    the location the warp points to; must not be {@code null}
+     * @param creatorUUID the UUID of the player setting the warp; must not be {@code null}
+     */
+    public TeamWarpSetEvent(
+            final Team team,
+            final String name,
+            final Location location,
+            final UUID creatorUUID) {
+        super(team);
+        this.name = name;
+        this.location = location;
+        this.creatorUUID = creatorUUID;
+    }
+
+    /**
+     * Returns the name of the warp being set.
+     *
+     * @return the warp name; never {@code null}
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the location the warp points to.
+     *
+     * @return the warp {@link Location}; never {@code null}
+     */
+    public Location getLocation() {
+        return location;
+    }
+
+    /**
+     * Returns the UUID of the player who is setting the warp.
+     *
+     * @return the creator's UUID; never {@code null}
+     */
+    public UUID getCreatorUUID() {
+        return creatorUUID;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamWarp.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamWarp.java
@@ -1,0 +1,57 @@
+package com.skyblockexp.teamsapi.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.bukkit.Location;
+
+/**
+ * Represents a named warp point belonging to a {@link Team}.
+ *
+ * <p>Implementations returned by a provider are read-only snapshots of a warp at a
+ * specific point in time. To modify warp data, use the mutation methods on
+ * {@link com.skyblockexp.teamsapi.api.TeamsWarpService}.</p>
+ */
+public interface TeamWarp {
+
+    /**
+     * Returns the ID of the team this warp belongs to.
+     *
+     * @return the team's UUID; never {@code null}
+     */
+    UUID getTeamId();
+
+    /**
+     * Returns the name of this warp.
+     *
+     * <p>Warp names are unique within a team. Name uniqueness and case-sensitivity
+     * depend on the provider.</p>
+     *
+     * @return the warp name; never {@code null}
+     */
+    String getName();
+
+    /**
+     * Returns the location this warp points to.
+     *
+     * @return the warp {@link Location}; never {@code null}
+     */
+    Location getLocation();
+
+    /**
+     * Returns the UUID of the player who created or last updated this warp.
+     *
+     * @return the creator's UUID; never {@code null}
+     */
+    UUID getCreatorUUID();
+
+    /**
+     * Returns the instant at which this warp was created or last updated.
+     *
+     * <p>If the backing implementation does not track creation times, this method
+     * may return {@link Instant#EPOCH} as a sentinel value.</p>
+     *
+     * @return the creation timestamp; never {@code null}
+     */
+    Instant getCreatedAt();
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIWarpTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIWarpTest.java
@@ -1,0 +1,173 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsWarpService} registration methods on {@link TeamsAPI}.
+ *
+ * <p>Tests verify that the warp service facade correctly delegates to Bukkit's
+ * ServicesManager and that null-safety contracts hold, mirroring {@link TeamsAPIInviteTest}.</p>
+ */
+class TeamsAPIWarpTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isWarpAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isWarpAvailable()} returns {@code false} when no warp provider
+     * has been registered.
+     */
+    @Test
+    void isWarpAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isWarpAvailable());
+    }
+
+    /**
+     * getWarpService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getWarpService()} returns {@code null} when no warp provider
+     * has been registered.
+     */
+    @Test
+    void getWarpService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getWarpService());
+    }
+
+    /**
+     * registerWarpProvider_makesWarpServiceAvailable verifies that after registering
+     * a warp provider, {@link TeamsAPI#isWarpAvailable()} returns {@code true} and
+     * {@link TeamsAPI#getWarpService()} returns the registered provider.
+     */
+    @Test
+    void registerWarpProvider_makesWarpServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(plugin, mockWarp);
+
+        assertTrue(TeamsAPI.isWarpAvailable());
+        assertEquals(mockWarp, TeamsAPI.getWarpService());
+    }
+
+    /**
+     * unregisterWarpProvider_makesWarpServiceUnavailable verifies that after
+     * unregistering a warp provider, {@link TeamsAPI#isWarpAvailable()} returns
+     * {@code false}.
+     */
+    @Test
+    void unregisterWarpProvider_makesWarpServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(plugin, mockWarp);
+        TeamsAPI.unregisterWarpProvider(mockWarp);
+
+        assertFalse(TeamsAPI.isWarpAvailable());
+    }
+
+    /**
+     * registerWarpProvider_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin does not register anything.
+     */
+    @Test
+    void registerWarpProvider_withNullPlugin_doesNotRegister() {
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(null, mockWarp);
+
+        assertFalse(TeamsAPI.isWarpAvailable());
+    }
+
+    /**
+     * registerWarpProvider_withNullProvider_doesNotRegister verifies that passing a
+     * {@code null} provider does not register anything.
+     */
+    @Test
+    void registerWarpProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerWarpProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isWarpAvailable());
+    }
+
+    /**
+     * unregisterWarpProvider_withNull_doesNotThrow verifies that passing {@code null}
+     * to {@link TeamsAPI#unregisterWarpProvider(TeamsWarpService)} does not throw.
+     */
+    @Test
+    void unregisterWarpProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterWarpProvider(null);
+        // No exception expected
+    }
+
+    /**
+     * registerWarpProvider_withPriority_registersCorrectly verifies that the overload
+     * accepting a {@link org.bukkit.plugin.ServicePriority} registers the warp provider
+     * successfully.
+     */
+    @Test
+    void registerWarpProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(plugin, mockWarp,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isWarpAvailable());
+        assertEquals(mockWarp, TeamsAPI.getWarpService());
+    }
+
+    /**
+     * registerWarpProvider_withPriority_withNullPriority_doesNotRegister verifies that
+     * passing a {@code null} priority does not register anything.
+     */
+    @Test
+    void registerWarpProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(plugin, mockWarp, null);
+
+        assertFalse(TeamsAPI.isWarpAvailable());
+    }
+
+    /**
+     * warpService_isIndependentOfTeamsService verifies that registering only a warp
+     * provider does not affect {@link TeamsAPI#isAvailable()}, and vice versa.
+     */
+    @Test
+    void warpService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsWarpService mockWarp = mock(TeamsWarpService.class);
+
+        TeamsAPI.registerWarpProvider(plugin, mockWarp);
+
+        assertTrue(TeamsAPI.isWarpAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamWarpEventTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamWarpEventTest.java
@@ -1,0 +1,225 @@
+package com.skyblockexp.teamsapi.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.Location;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+/**
+ * Unit tests for the team warp events:
+ * {@link TeamWarpSetEvent} and {@link TeamWarpDeleteEvent}.
+ *
+ * <p>Tests verify constructors, getters, cancellable behaviour, and that each event
+ * exposes the correct static {@link org.bukkit.event.HandlerList}.</p>
+ */
+class TeamWarpEventTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamWarpSetEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamWarpSetEvent_getTeam_returnsTeam verifies that {@link TeamWarpSetEvent#getTeam()}
+     * returns the team passed to the constructor.
+     */
+    @Test
+    void teamWarpSetEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final Location location = mock(Location.class);
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(team, "home", location,
+            UUID.randomUUID());
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamWarpSetEvent_getName_returnsName verifies that {@link TeamWarpSetEvent#getName()}
+     * returns the warp name passed to the constructor.
+     */
+    @Test
+    void teamWarpSetEvent_getName_returnsName() {
+        final Location location = mock(Location.class);
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "base", location,
+            UUID.randomUUID());
+
+        assertEquals("base", event.getName());
+    }
+
+    /**
+     * teamWarpSetEvent_getLocation_returnsLocation verifies that
+     * {@link TeamWarpSetEvent#getLocation()} returns the location passed to the constructor.
+     */
+    @Test
+    void teamWarpSetEvent_getLocation_returnsLocation() {
+        final Location location = mock(Location.class);
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "home", location,
+            UUID.randomUUID());
+
+        assertEquals(location, event.getLocation());
+    }
+
+    /**
+     * teamWarpSetEvent_getCreatorUUID_returnsCreator verifies that
+     * {@link TeamWarpSetEvent#getCreatorUUID()} returns the creator UUID passed to
+     * the constructor.
+     */
+    @Test
+    void teamWarpSetEvent_getCreatorUUID_returnsCreator() {
+        final UUID creator = UUID.randomUUID();
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "home",
+            mock(Location.class), creator);
+
+        assertEquals(creator, event.getCreatorUUID());
+    }
+
+    /**
+     * teamWarpSetEvent_isCancelled_returnsFalse_byDefault verifies that
+     * {@link TeamWarpSetEvent} is not cancelled by default.
+     */
+    @Test
+    void teamWarpSetEvent_isCancelled_returnsFalse_byDefault() {
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "home",
+            mock(Location.class), UUID.randomUUID());
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamWarpSetEvent_setCancelled_returnsTrue_whenCancelled verifies that cancelling
+     * a {@link TeamWarpSetEvent} causes {@link TeamWarpSetEvent#isCancelled()} to return
+     * {@code true}.
+     */
+    @Test
+    void teamWarpSetEvent_setCancelled_returnsTrue_whenCancelled() {
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "home",
+            mock(Location.class), UUID.randomUUID());
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    /**
+     * teamWarpSetEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamWarpSetEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamWarpSetEvent.getHandlerList());
+    }
+
+    /**
+     * teamWarpSetEvent_getHandlers_matchesStaticHandlerList verifies that
+     * {@link TeamWarpSetEvent#getHandlers()} returns the same instance as the static
+     * {@code getHandlerList()} method.
+     */
+    @Test
+    void teamWarpSetEvent_getHandlers_matchesStaticHandlerList() {
+        final TeamWarpSetEvent event = new TeamWarpSetEvent(mock(Team.class), "home",
+            mock(Location.class), UUID.randomUUID());
+
+        assertEquals(TeamWarpSetEvent.getHandlerList(), event.getHandlers());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamWarpDeleteEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamWarpDeleteEvent_getTeam_returnsTeam verifies that
+     * {@link TeamWarpDeleteEvent#getTeam()} returns the team passed to the constructor.
+     */
+    @Test
+    void teamWarpDeleteEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final TeamWarpDeleteEvent event = new TeamWarpDeleteEvent(team, "home");
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamWarpDeleteEvent_getName_returnsName verifies that
+     * {@link TeamWarpDeleteEvent#getName()} returns the warp name passed to the constructor.
+     */
+    @Test
+    void teamWarpDeleteEvent_getName_returnsName() {
+        final TeamWarpDeleteEvent event = new TeamWarpDeleteEvent(mock(Team.class), "base");
+
+        assertEquals("base", event.getName());
+    }
+
+    /**
+     * teamWarpDeleteEvent_isCancelled_returnsFalse_byDefault verifies that
+     * {@link TeamWarpDeleteEvent} is not cancelled by default.
+     */
+    @Test
+    void teamWarpDeleteEvent_isCancelled_returnsFalse_byDefault() {
+        final TeamWarpDeleteEvent event = new TeamWarpDeleteEvent(mock(Team.class), "home");
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamWarpDeleteEvent_setCancelled_returnsTrue_whenCancelled verifies that cancelling
+     * a {@link TeamWarpDeleteEvent} causes {@link TeamWarpDeleteEvent#isCancelled()} to
+     * return {@code true}.
+     */
+    @Test
+    void teamWarpDeleteEvent_setCancelled_returnsTrue_whenCancelled() {
+        final TeamWarpDeleteEvent event = new TeamWarpDeleteEvent(mock(Team.class), "home");
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    /**
+     * teamWarpDeleteEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamWarpDeleteEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamWarpDeleteEvent.getHandlerList());
+    }
+
+    /**
+     * teamWarpDeleteEvent_getHandlers_matchesStaticHandlerList verifies that
+     * {@link TeamWarpDeleteEvent#getHandlers()} returns the same instance as the static
+     * {@code getHandlerList()} method.
+     */
+    @Test
+    void teamWarpDeleteEvent_getHandlers_matchesStaticHandlerList() {
+        final TeamWarpDeleteEvent event = new TeamWarpDeleteEvent(mock(Team.class), "home");
+
+        assertEquals(TeamWarpDeleteEvent.getHandlerList(), event.getHandlers());
+    }
+}


### PR DESCRIPTION
- Add TeamWarp model interface (getTeamId, getName, getLocation, getCreatorUUID, getCreatedAt)
- Add TeamsWarpService interface (setWarp, removeWarp, getWarp, getWarps)
- Add TeamWarpSetEvent (cancellable, fired before setWarp)
- Add TeamWarpDeleteEvent (cancellable, fired before removeWarp)
- Add warp provider registration/lookup to TeamsAPI facade (getWarpService, isWarpAvailable, registerWarpProvider, unregisterWarpProvider)
- Add TeamsAPIWarpTest mirroring TeamsAPIInviteTest
- Add TeamWarpEventTest mirroring TeamInviteEventTest