### PR TITLE
fix: correct JitPack build and bump version to 1.2.1

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,6 +2,6 @@ jdk:
   - openjdk25
 
 install:
-  - git clone --depth=1 --branch dev/26.1.1 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
-  - cd /tmp/MockBukkit && ./gradlew publishToMavenLocal -xtest -xjavadoc
-  - cd $HOME/build && ./mvnw --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true
+  - git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
+  - cd /tmp/MockBukkit && git rev-parse --short HEAD > /tmp/mb-version.txt && ./gradlew publishToMavenLocal -x test
+  - ./mvnw --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true "-Dmockbukkit.version=dev-$(cat /tmp/mb-version.txt)"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft — bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -45,7 +45,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.2.0";
+    public static final String API_VERSION = "1.2.1";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }


### PR DESCRIPTION
jitpack.yml:
- Clone MockBukkit from minecraft/v26 (dev/26.1.1 was deleted)
- Capture dynamic version via git rev-parse and write to /tmp/mb-version.txt
- Pass -Dmockbukkit.version=dev-$(cat /tmp/mb-version.txt) to mvnw so Maven resolves the correct local artifact instead of 0.0.0-unset

Version: 1.2.0 -> 1.2.1 (patch; build-system fix, no API changes)