### PR TITLE
fix: restore cd $HOME/build in jitpack.yml, bump to 1.2.2

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,4 +4,4 @@ jdk:
 install:
   - git clone --depth=1 --branch minecraft/v26 https://github.com/MockBukkit/MockBukkit.git /tmp/MockBukkit
   - cd /tmp/MockBukkit && git rev-parse --short HEAD > /tmp/mb-version.txt && ./gradlew publishToMavenLocal -x test
-  - ./mvnw --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true "-Dmockbukkit.version=dev-$(cat /tmp/mb-version.txt)"
+  - cd $HOME/build && ./mvnw --batch-mode --no-transfer-progress clean install -Dmaven.test.skip=true "-Dmockbukkit.version=dev-$(cat /tmp/mb-version.txt)"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft — bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -45,7 +45,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.2.1";
+    public static final String API_VERSION = "1.2.2";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }


### PR DESCRIPTION
JitPack does not set the working directory to the project root for install commands, so ./mvnw failed with 'No such file or directory'. Restore the explicit 'cd $HOME/build &&' prefix from the original.

Version: 1.2.1 -> 1.2.2 (patch; build-system fix, no API changes)