### PR TITLE
Claims & Power

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,26 @@ Entry point for all API interactions. All methods are static.
 | `registerWarpProvider(plugin, service, priority)` | Registers a warp provider at the given priority. |
 | `unregisterWarpProvider(service)` | Unregisters a warp provider from Bukkit's ServicesManager. |
 
+**Claim service**
+
+| Method | Description |
+|--------|-------------|
+| `getClaimService()` | Returns the active `TeamsClaimService`, or `null` if none is registered. |
+| `isClaimAvailable()` | Returns `true` when a claim provider is registered. |
+| `registerClaimProvider(plugin, service)` | Registers a claim provider at `ServicePriority.Normal`. |
+| `registerClaimProvider(plugin, service, priority)` | Registers a claim provider at the given priority. |
+| `unregisterClaimProvider(service)` | Unregisters a claim provider from Bukkit's ServicesManager. |
+
+**Power service**
+
+| Method | Description |
+|--------|-------------|
+| `getPowerService()` | Returns the active `TeamsPowerService`, or `null` if none is registered. |
+| `isPowerAvailable()` | Returns `true` when a power provider is registered. |
+| `registerPowerProvider(plugin, service)` | Registers a power provider at `ServicePriority.Normal`. |
+| `registerPowerProvider(plugin, service, priority)` | Registers a power provider at the given priority. |
+| `unregisterPowerProvider(service)` | Unregisters a power provider from Bukkit's ServicesManager. |
+
 ## `TeamsService` (interface)
 
 Implemented by team plugins. Obtained via `TeamsAPI.getService()`.
@@ -114,6 +134,41 @@ Existing `TeamsService` implementations are not required to support it.
 | `getWarp(teamId, name)` | `Optional<TeamWarp>` | Returns the named warp, or empty if it does not exist. |
 | `getWarps(teamId)` | `Collection<TeamWarp>` | Returns all warps for the team. Never `null`; empty if the team has no warps. |
 
+## `TeamsClaimService` (interface)
+
+Optional extension service for team chunk-claim management. Providers that support
+land claiming register an implementation via `TeamsAPI.registerClaimProvider()`.
+Existing `TeamsService` implementations are not required to support it.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `claimChunk(teamId, playerUUID, worldName, chunkX, chunkZ)` | `boolean` | Claims the chunk for the team. Providers should fire `TeamClaimEvent` before persisting; return `false` if cancelled, already claimed, or the team lacks enough power. |
+| `unclaimChunk(teamId, playerUUID, worldName, chunkX, chunkZ)` | `boolean` | Removes the team's claim on the chunk. Providers should fire `TeamUnclaimEvent` before removing; return `false` if cancelled or no claim existed. |
+| `unclaimAll(teamId)` | `boolean` | Removes all claims owned by the team (e.g. on disband). Individual unclaim events are not required. Returns `false` if the team had no claims. |
+| `getClaimAt(worldName, chunkX, chunkZ)` | `Optional<TeamClaim>` | Returns the claim at the given chunk, or empty if unclaimed. |
+| `getTeamClaims(teamId)` | `Collection<TeamClaim>` | All chunks claimed by the team. Never `null`; empty if the team has no claims. |
+| `getClaimCount(teamId)` | `int` | Number of chunks currently claimed by the team. Always `>= 0`. |
+| `isClaimed(worldName, chunkX, chunkZ)` | `boolean` | Whether any team owns the chunk. |
+| `isClaimedBy(teamId, worldName, chunkX, chunkZ)` | `boolean` | Whether the specific team owns the chunk. |
+| `getTeamMaxClaims(teamId)` | `int` | Maximum chunks the team may claim. `-1` means no limit. |
+
+## `TeamsPowerService` (interface)
+
+Optional extension service for team power management. Providers that expose a
+power system register an implementation via `TeamsAPI.registerPowerProvider()`.
+Existing `TeamsService` implementations are not required to support it.
+
+Power is modelled as a `double` to accommodate fractional accumulation over time.
+How power is gained, lost, and used to gate land claims is entirely up to the provider.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getPlayerPower(playerUUID)` | `double` | The player's current power. `0.0` if the player is unknown. |
+| `getPlayerMaxPower(playerUUID)` | `double` | The player's maximum power. `0.0` if the player is unknown. |
+| `setPlayerPower(playerUUID, power)` | `boolean` | Overrides the player's current power (clamped by the provider). Returns `false` if the player is unknown. |
+| `getTeamPower(teamId)` | `double` | Total power for the team (typically sum of member power plus any boost). `0.0` if the team is unknown. |
+| `getTeamMaxPower(teamId)` | `double` | Theoretical maximum power for the team (typically `maxPowerPerPlayer * memberCount`). `0.0` if the team is unknown. |
+
 ## `Team` (interface)
 
 A read-only snapshot of a team. Obtain via `TeamsService` lookup methods.
@@ -154,6 +209,19 @@ methods.
 | `getLocation()` | `Location` | The Bukkit `Location` this warp points to. |
 | `getCreatorUUID()` | `UUID` | UUID of the player who created or last updated this warp. |
 | `getCreatedAt()` | `Instant` | When the warp was created or last updated; may be `Instant.EPOCH` if unsupported. |
+
+## `TeamClaim` (interface)
+
+A read-only snapshot of a claimed chunk. Obtain via `TeamsClaimService` lookup
+methods.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getTeamId()` | `UUID` | The UUID of the team that owns this claim. |
+| `getWorldName()` | `String` | The name of the world the chunk is in. |
+| `getChunkX()` | `int` | The X coordinate of the claimed chunk. |
+| `getChunkZ()` | `int` | The Z coordinate of the claimed chunk. |
+| `getClaimedAt()` | `Instant` | When the chunk was claimed; may be `Instant.EPOCH` if the provider does not track this. |
 
 ## `TeamRole` (enum)
 
@@ -201,7 +269,28 @@ All concrete events implement `Cancellable`.
 | `TeamWarpSetEvent` | Yes | `getTeam()`, `getName()`, `getLocation()`, `getCreatorUUID()` |
 | `TeamWarpDeleteEvent` | Yes | `getTeam()`, `getName()` |
 
+**Claim events**
+
+| Class | Cancellable | Key fields |
+|-------|-------------|------------|
+| `TeamClaimEvent` | Yes | `getTeam()`, `getPlayerUUID()`, `getWorldName()`, `getChunkX()`, `getChunkZ()` |
+| `TeamUnclaimEvent` | Yes | `getTeam()`, `getPlayerUUID()`, `getWorldName()`, `getChunkX()`, `getChunkZ()` |
+
 ## Migration notes
+
+### 1.4.0
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- New optional `TeamsClaimService` interface for chunk-claim management.
+- New optional `TeamsPowerService` interface for player and team power.
+- New `TeamClaim` model interface.
+- New `TeamsAPI` static methods: `getClaimService()`, `isClaimAvailable()`,
+  `registerClaimProvider(...)`, `unregisterClaimProvider(...)`,
+  `getPowerService()`, `isPowerAvailable()`, `registerPowerProvider(...)`,
+  `unregisterPowerProvider(...)`.
+- New events: `TeamClaimEvent` (cancellable), `TeamUnclaimEvent` (cancellable).
+- `TeamsAPI.API_VERSION` bumped from `1.3.0` to `1.4.0`.
 
 ### 1.3.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.4.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -45,7 +45,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.3.0";
+    public static final String API_VERSION = "1.4.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }
@@ -337,5 +337,195 @@ public final class TeamsAPI {
         }
 
         Bukkit.getServicesManager().unregister(TeamsWarpService.class, provider);
+    }
+
+    // -------------------------------------------------------------------------
+    // Claim provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsClaimService} provider, or {@code null}
+     * if no claim provider has been registered.
+     *
+     * <p>Consumers should check {@link #isClaimAvailable()} before calling this method
+     * to handle gracefully the case where no team plugin supports chunk claiming.</p>
+     *
+     * @return the active {@link TeamsClaimService}, or {@code null} if unavailable
+     */
+    public static TeamsClaimService getClaimService() {
+        try {
+            final RegisteredServiceProvider<TeamsClaimService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsClaimService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsClaimService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if a claim provider is available, {@code false} otherwise
+     */
+    public static boolean isClaimAvailable() {
+        return getClaimService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsClaimService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsClaimService} implementation; must not be {@code null}
+     */
+    public static void registerClaimProvider(final Plugin plugin,
+            final TeamsClaimService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsClaimService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsClaimService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsClaimService} implementation; must not be {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerClaimProvider(
+            final Plugin plugin,
+            final TeamsClaimService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsClaimService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsClaimService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsClaimService} provider to unregister; may be {@code null}
+     */
+    public static void unregisterClaimProvider(final TeamsClaimService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsClaimService.class, provider);
+    }
+
+    // -------------------------------------------------------------------------
+    // Power provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsPowerService} provider, or {@code null}
+     * if no power provider has been registered.
+     *
+     * <p>Consumers should check {@link #isPowerAvailable()} before calling this method
+     * to handle gracefully the case where no team plugin exposes a power system.</p>
+     *
+     * @return the active {@link TeamsPowerService}, or {@code null} if unavailable
+     */
+    public static TeamsPowerService getPowerService() {
+        try {
+            final RegisteredServiceProvider<TeamsPowerService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsPowerService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsPowerService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if a power provider is available, {@code false} otherwise
+     */
+    public static boolean isPowerAvailable() {
+        return getPowerService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsPowerService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsPowerService} implementation; must not be {@code null}
+     */
+    public static void registerPowerProvider(final Plugin plugin,
+            final TeamsPowerService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsPowerService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsPowerService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsPowerService} implementation; must not be {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerPowerProvider(
+            final Plugin plugin,
+            final TeamsPowerService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsPowerService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsPowerService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsPowerService} provider to unregister; may be {@code null}
+     */
+    public static void unregisterPowerProvider(final TeamsPowerService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsPowerService.class, provider);
     }
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsClaimService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsClaimService.java
@@ -1,0 +1,149 @@
+package com.skyblockexp.teamsapi.api;
+
+import com.skyblockexp.teamsapi.model.TeamClaim;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Optional extension service for team chunk-claim management.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to support
+ * chunk claiming register an implementation separately via
+ * {@link TeamsAPI#registerClaimProvider(org.bukkit.plugin.Plugin, TeamsClaimService)}.
+ * Consumers first check whether the service is available with
+ * {@link TeamsAPI#isClaimAvailable()} before calling {@link TeamsAPI#getClaimService()}.</p>
+ *
+ * <p>Existing {@link TeamsService} implementations are not required to implement this
+ * interface; omitting it is a supported configuration and the API will degrade gracefully.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // In your team plugin's onEnable():
+ * TeamsAPI.registerClaimProvider(this, new MyClaimServiceImpl());
+ *
+ * // In your team plugin's onDisable():
+ * TeamsAPI.unregisterClaimProvider(myClaimService);
+ * }</pre>
+ *
+ * <p><strong>Consumer usage example:</strong></p>
+ * <pre>{@code
+ * TeamsClaimService claims = TeamsAPI.getClaimService();
+ * if (claims == null) {
+ *     player.sendMessage("Chunk claiming is not supported by the active team plugin.");
+ *     return;
+ * }
+ * claims.getClaimAt(world.getName(), chunk.getX(), chunk.getZ())
+ *     .ifPresent(c -> player.sendMessage("Owned by team: " + c.getTeamId()));
+ * }</pre>
+ */
+public interface TeamsClaimService {
+
+    /**
+     * Claims the given chunk for the given team on behalf of the given player.
+     *
+     * <p>Providers should fire {@link com.skyblockexp.teamsapi.event.TeamClaimEvent}
+     * before persisting the claim. If the event is cancelled, implementations should
+     * return {@code false}.</p>
+     *
+     * @param teamId    the UUID of the team claiming the chunk; must not be {@code null}
+     * @param playerUUID the UUID of the player performing the claim; must not be {@code null}
+     * @param worldName the name of the world the chunk is in; must not be {@code null}
+     * @param chunkX    the X coordinate of the chunk
+     * @param chunkZ    the Z coordinate of the chunk
+     * @return {@code true} if the claim was recorded successfully, {@code false} otherwise
+     *         (e.g. the chunk is already claimed, the team lacks enough power, or the
+     *         event was cancelled)
+     */
+    boolean claimChunk(UUID teamId, UUID playerUUID, String worldName, int chunkX, int chunkZ);
+
+    /**
+     * Unclaims the given chunk from the given team on behalf of the given player.
+     *
+     * <p>Providers should fire {@link com.skyblockexp.teamsapi.event.TeamUnclaimEvent}
+     * before removing the claim. If the event is cancelled, implementations should
+     * return {@code false}.</p>
+     *
+     * @param teamId    the UUID of the team that owns the claim; must not be {@code null}
+     * @param playerUUID the UUID of the player performing the unclaim; must not be {@code null}
+     * @param worldName the name of the world the chunk is in; must not be {@code null}
+     * @param chunkX    the X coordinate of the chunk
+     * @param chunkZ    the Z coordinate of the chunk
+     * @return {@code true} if the claim existed and was removed, {@code false} otherwise
+     */
+    boolean unclaimChunk(UUID teamId, UUID playerUUID, String worldName, int chunkX, int chunkZ);
+
+    /**
+     * Removes all chunk claims belonging to the given team.
+     *
+     * <p>This method is intended for use when a team is disbanded. Individual unclaim events
+     * are not required to be fired per chunk; implementations may batch the removal.</p>
+     *
+     * @param teamId the UUID of the team whose claims should be removed; must not be {@code null}
+     * @return {@code true} if any claims existed and were removed, {@code false} if the team
+     *         had no claims
+     */
+    boolean unclaimAll(UUID teamId);
+
+    /**
+     * Returns the claim at the given chunk coordinates, if any.
+     *
+     * @param worldName the name of the world; must not be {@code null}
+     * @param chunkX    the X coordinate of the chunk
+     * @param chunkZ    the Z coordinate of the chunk
+     * @return an {@link Optional} containing the {@link TeamClaim}, or empty if the chunk
+     *         is unclaimed
+     */
+    Optional<TeamClaim> getClaimAt(String worldName, int chunkX, int chunkZ);
+
+    /**
+     * Returns all chunks currently claimed by the given team.
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return an unmodifiable collection of {@link TeamClaim}s; never {@code null},
+     *         empty if the team has no claims or does not exist
+     */
+    Collection<TeamClaim> getTeamClaims(UUID teamId);
+
+    /**
+     * Returns the number of chunks currently claimed by the given team.
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return the claim count; always {@code >= 0}
+     */
+    int getClaimCount(UUID teamId);
+
+    /**
+     * Returns {@code true} if the given chunk is claimed by any team.
+     *
+     * @param worldName the name of the world; must not be {@code null}
+     * @param chunkX    the X coordinate of the chunk
+     * @param chunkZ    the Z coordinate of the chunk
+     * @return {@code true} if the chunk has an owner, {@code false} if it is wilderness
+     */
+    boolean isClaimed(String worldName, int chunkX, int chunkZ);
+
+    /**
+     * Returns {@code true} if the given chunk is claimed by the specific team.
+     *
+     * @param teamId    the UUID of the team to check; must not be {@code null}
+     * @param worldName the name of the world; must not be {@code null}
+     * @param chunkX    the X coordinate of the chunk
+     * @param chunkZ    the Z coordinate of the chunk
+     * @return {@code true} if the chunk is owned by the given team, {@code false} otherwise
+     */
+    boolean isClaimedBy(UUID teamId, String worldName, int chunkX, int chunkZ);
+
+    /**
+     * Returns the maximum number of chunks the given team is currently allowed to claim.
+     *
+     * <p>The ceiling is provider-defined and typically based on total team power
+     * (e.g. {@code totalPower / landPerPower}). A return value of {@code -1} indicates
+     * that the provider imposes no upper limit for this team.</p>
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return the maximum number of claimable chunks, or {@code -1} for unlimited
+     */
+    int getTeamMaxClaims(UUID teamId);
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsPowerService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsPowerService.java
@@ -1,0 +1,96 @@
+package com.skyblockexp.teamsapi.api;
+
+import java.util.UUID;
+
+/**
+ * Optional extension service for team power management.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to expose
+ * their power system register an implementation separately via
+ * {@link TeamsAPI#registerPowerProvider(org.bukkit.plugin.Plugin, TeamsPowerService)}.
+ * Consumers first check whether the service is available with
+ * {@link TeamsAPI#isPowerAvailable()} before calling {@link TeamsAPI#getPowerService()}.</p>
+ *
+ * <p>Existing {@link TeamsService} implementations are not required to implement this
+ * interface; omitting it is a supported configuration and the API will degrade gracefully.</p>
+ *
+ * <p>Power is modelled as a {@code double} to accommodate fractional accumulation over time.
+ * How power is gained, lost, and used to gate land claims is entirely up to the provider.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // In your team plugin's onEnable():
+ * TeamsAPI.registerPowerProvider(this, new MyPowerServiceImpl());
+ *
+ * // In your team plugin's onDisable():
+ * TeamsAPI.unregisterPowerProvider(myPowerService);
+ * }</pre>
+ *
+ * <p><strong>Consumer usage example:</strong></p>
+ * <pre>{@code
+ * TeamsPowerService power = TeamsAPI.getPowerService();
+ * if (power == null) {
+ *     player.sendMessage("Power is not supported by the active team plugin.");
+ *     return;
+ * }
+ * double current = power.getPlayerPower(player.getUniqueId());
+ * player.sendMessage("Your power: " + current);
+ * }</pre>
+ */
+public interface TeamsPowerService {
+
+    /**
+     * Returns the current accumulated power for the given player.
+     *
+     * @param playerUUID the UUID of the player; must not be {@code null}
+     * @return the player's current power; {@code 0.0} if the player is unknown to the provider
+     */
+    double getPlayerPower(UUID playerUUID);
+
+    /**
+     * Returns the maximum power the given player can accumulate.
+     *
+     * <p>This ceiling is provider-defined and may vary per player (e.g. based on rank or
+     * administrator adjustments).</p>
+     *
+     * @param playerUUID the UUID of the player; must not be {@code null}
+     * @return the player's maximum power; {@code 0.0} if the player is unknown to the provider
+     */
+    double getPlayerMaxPower(UUID playerUUID);
+
+    /**
+     * Overrides the current power for the given player.
+     *
+     * <p>The value is clamped to the provider's configured range. This method is intended for
+     * administrator adjustments.</p>
+     *
+     * @param playerUUID the UUID of the player; must not be {@code null}
+     * @param power      the new power value to set
+     * @return {@code true} if the value was applied, {@code false} if the player is unknown
+     *         to the provider
+     */
+    boolean setPlayerPower(UUID playerUUID, double power);
+
+    /**
+     * Returns the total power for the given team.
+     *
+     * <p>Total power is typically the sum of all member power values plus any
+     * administrator power boost applied to the team. The exact formula is
+     * provider-defined.</p>
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return the team's total power; {@code 0.0} if the team is unknown to the provider
+     */
+    double getTeamPower(UUID teamId);
+
+    /**
+     * Returns the theoretical maximum power for the given team.
+     *
+     * <p>This is typically {@code maxPowerPerPlayer * memberCount}. The actual total power
+     * may be lower if members have not yet accumulated their maximum.</p>
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return the team's maximum possible power; {@code 0.0} if the team is unknown
+     */
+    double getTeamMaxPower(UUID teamId);
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamClaimEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamClaimEvent.java
@@ -1,0 +1,128 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a team is about to claim a chunk.
+ *
+ * <p>Providers should fire this event before persisting the claim. If the event is
+ * cancelled, the claim must not be recorded and
+ * {@link com.skyblockexp.teamsapi.api.TeamsClaimService#claimChunk} should return
+ * {@code false}.</p>
+ */
+public class TeamClaimEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The UUID of the player performing the claim. */
+    private final UUID playerUUID;
+
+    /** The name of the world the chunk is in. */
+    private final String worldName;
+
+    /** The X coordinate of the chunk being claimed. */
+    private final int chunkX;
+
+    /** The Z coordinate of the chunk being claimed. */
+    private final int chunkZ;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamClaimEvent}.
+     *
+     * @param team       the team claiming the chunk; must not be {@code null}
+     * @param playerUUID the UUID of the player performing the claim; must not be {@code null}
+     * @param worldName  the name of the world the chunk is in; must not be {@code null}
+     * @param chunkX     the X coordinate of the chunk
+     * @param chunkZ     the Z coordinate of the chunk
+     */
+    public TeamClaimEvent(
+            final Team team,
+            final UUID playerUUID,
+            final String worldName,
+            final int chunkX,
+            final int chunkZ) {
+        super(team);
+        this.playerUUID = playerUUID;
+        this.worldName = worldName;
+        this.chunkX = chunkX;
+        this.chunkZ = chunkZ;
+    }
+
+    /**
+     * Returns the UUID of the player performing the claim.
+     *
+     * @return the player's UUID; never {@code null}
+     */
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    /**
+     * Returns the name of the world the chunk is in.
+     *
+     * @return the world name; never {@code null}
+     */
+    public String getWorldName() {
+        return worldName;
+    }
+
+    /**
+     * Returns the X coordinate of the chunk being claimed.
+     *
+     * @return the chunk X coordinate
+     */
+    public int getChunkX() {
+        return chunkX;
+    }
+
+    /**
+     * Returns the Z coordinate of the chunk being claimed.
+     *
+     * @return the chunk Z coordinate
+     */
+    public int getChunkZ() {
+        return chunkZ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamUnclaimEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamUnclaimEvent.java
@@ -1,0 +1,128 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a team is about to unclaim a chunk.
+ *
+ * <p>Providers should fire this event before removing the claim. If the event is
+ * cancelled, the claim must not be removed and
+ * {@link com.skyblockexp.teamsapi.api.TeamsClaimService#unclaimChunk} should return
+ * {@code false}.</p>
+ */
+public class TeamUnclaimEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The UUID of the player performing the unclaim. */
+    private final UUID playerUUID;
+
+    /** The name of the world the chunk is in. */
+    private final String worldName;
+
+    /** The X coordinate of the chunk being unclaimed. */
+    private final int chunkX;
+
+    /** The Z coordinate of the chunk being unclaimed. */
+    private final int chunkZ;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamUnclaimEvent}.
+     *
+     * @param team       the team unclaiming the chunk; must not be {@code null}
+     * @param playerUUID the UUID of the player performing the unclaim; must not be {@code null}
+     * @param worldName  the name of the world the chunk is in; must not be {@code null}
+     * @param chunkX     the X coordinate of the chunk
+     * @param chunkZ     the Z coordinate of the chunk
+     */
+    public TeamUnclaimEvent(
+            final Team team,
+            final UUID playerUUID,
+            final String worldName,
+            final int chunkX,
+            final int chunkZ) {
+        super(team);
+        this.playerUUID = playerUUID;
+        this.worldName = worldName;
+        this.chunkX = chunkX;
+        this.chunkZ = chunkZ;
+    }
+
+    /**
+     * Returns the UUID of the player performing the unclaim.
+     *
+     * @return the player's UUID; never {@code null}
+     */
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+
+    /**
+     * Returns the name of the world the chunk is in.
+     *
+     * @return the world name; never {@code null}
+     */
+    public String getWorldName() {
+        return worldName;
+    }
+
+    /**
+     * Returns the X coordinate of the chunk being unclaimed.
+     *
+     * @return the chunk X coordinate
+     */
+    public int getChunkX() {
+        return chunkX;
+    }
+
+    /**
+     * Returns the Z coordinate of the chunk being unclaimed.
+     *
+     * @return the chunk Z coordinate
+     */
+    public int getChunkZ() {
+        return chunkZ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the shared {@link HandlerList} for this event type.
+     *
+     * @return the handler list; never {@code null}
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamClaim.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamClaim.java
@@ -1,0 +1,52 @@
+package com.skyblockexp.teamsapi.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a single chunk claimed by a {@link Team}.
+ *
+ * <p>Implementations returned by a {@link com.skyblockexp.teamsapi.api.TeamsClaimService}
+ * are read-only snapshots. To modify claim data, use the mutation methods on
+ * {@link com.skyblockexp.teamsapi.api.TeamsClaimService} directly.</p>
+ */
+public interface TeamClaim {
+
+    /**
+     * Returns the UUID of the team that owns this claim.
+     *
+     * @return the team's UUID; never {@code null}
+     */
+    UUID getTeamId();
+
+    /**
+     * Returns the name of the world in which this chunk is located.
+     *
+     * @return the Bukkit world name; never {@code null}
+     */
+    String getWorldName();
+
+    /**
+     * Returns the X coordinate of the claimed chunk.
+     *
+     * @return the chunk X coordinate
+     */
+    int getChunkX();
+
+    /**
+     * Returns the Z coordinate of the claimed chunk.
+     *
+     * @return the chunk Z coordinate
+     */
+    int getChunkZ();
+
+    /**
+     * Returns the instant at which this chunk was claimed.
+     *
+     * <p>If the backing implementation does not track claim times, this method
+     * may return {@link Instant#EPOCH} as a sentinel value.</p>
+     *
+     * @return the claim timestamp; never {@code null}
+     */
+    Instant getClaimedAt();
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIClaimTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIClaimTest.java
@@ -1,0 +1,173 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsClaimService} registration methods on {@link TeamsAPI}.
+ *
+ * <p>Tests verify that the claim service facade correctly delegates to Bukkit's
+ * ServicesManager and that null-safety contracts hold, mirroring {@link TeamsAPIWarpTest}.</p>
+ */
+class TeamsAPIClaimTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isClaimAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isClaimAvailable()} returns {@code false} when no claim provider
+     * has been registered.
+     */
+    @Test
+    void isClaimAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isClaimAvailable());
+    }
+
+    /**
+     * getClaimService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getClaimService()} returns {@code null} when no claim provider
+     * has been registered.
+     */
+    @Test
+    void getClaimService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getClaimService());
+    }
+
+    /**
+     * registerClaimProvider_makesClaimServiceAvailable verifies that after registering
+     * a claim provider, {@link TeamsAPI#isClaimAvailable()} returns {@code true} and
+     * {@link TeamsAPI#getClaimService()} returns the registered provider.
+     */
+    @Test
+    void registerClaimProvider_makesClaimServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(plugin, mockClaim);
+
+        assertTrue(TeamsAPI.isClaimAvailable());
+        assertEquals(mockClaim, TeamsAPI.getClaimService());
+    }
+
+    /**
+     * unregisterClaimProvider_makesClaimServiceUnavailable verifies that after
+     * unregistering a claim provider, {@link TeamsAPI#isClaimAvailable()} returns
+     * {@code false}.
+     */
+    @Test
+    void unregisterClaimProvider_makesClaimServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(plugin, mockClaim);
+        TeamsAPI.unregisterClaimProvider(mockClaim);
+
+        assertFalse(TeamsAPI.isClaimAvailable());
+    }
+
+    /**
+     * registerClaimProvider_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin does not register anything.
+     */
+    @Test
+    void registerClaimProvider_withNullPlugin_doesNotRegister() {
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(null, mockClaim);
+
+        assertFalse(TeamsAPI.isClaimAvailable());
+    }
+
+    /**
+     * registerClaimProvider_withNullProvider_doesNotRegister verifies that passing a
+     * {@code null} provider does not register anything.
+     */
+    @Test
+    void registerClaimProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerClaimProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isClaimAvailable());
+    }
+
+    /**
+     * unregisterClaimProvider_withNull_doesNotThrow verifies that passing {@code null}
+     * to {@link TeamsAPI#unregisterClaimProvider(TeamsClaimService)} does not throw.
+     */
+    @Test
+    void unregisterClaimProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterClaimProvider(null);
+        // No exception expected
+    }
+
+    /**
+     * registerClaimProvider_withPriority_registersCorrectly verifies that the overload
+     * accepting a {@link org.bukkit.plugin.ServicePriority} registers the claim provider
+     * successfully.
+     */
+    @Test
+    void registerClaimProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(plugin, mockClaim,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isClaimAvailable());
+        assertEquals(mockClaim, TeamsAPI.getClaimService());
+    }
+
+    /**
+     * registerClaimProvider_withPriority_withNullPriority_doesNotRegister verifies that
+     * passing a {@code null} priority does not register anything.
+     */
+    @Test
+    void registerClaimProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(plugin, mockClaim, null);
+
+        assertFalse(TeamsAPI.isClaimAvailable());
+    }
+
+    /**
+     * claimService_isIndependentOfTeamsService verifies that registering only a claim
+     * provider does not affect {@link TeamsAPI#isAvailable()}, and vice versa.
+     */
+    @Test
+    void claimService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsClaimService mockClaim = mock(TeamsClaimService.class);
+
+        TeamsAPI.registerClaimProvider(plugin, mockClaim);
+
+        assertTrue(TeamsAPI.isClaimAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIPowerTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIPowerTest.java
@@ -1,0 +1,173 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsPowerService} registration methods on {@link TeamsAPI}.
+ *
+ * <p>Tests verify that the power service facade correctly delegates to Bukkit's
+ * ServicesManager and that null-safety contracts hold, mirroring {@link TeamsAPIWarpTest}.</p>
+ */
+class TeamsAPIPowerTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isPowerAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isPowerAvailable()} returns {@code false} when no power provider
+     * has been registered.
+     */
+    @Test
+    void isPowerAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isPowerAvailable());
+    }
+
+    /**
+     * getPowerService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getPowerService()} returns {@code null} when no power provider
+     * has been registered.
+     */
+    @Test
+    void getPowerService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getPowerService());
+    }
+
+    /**
+     * registerPowerProvider_makesPowerServiceAvailable verifies that after registering
+     * a power provider, {@link TeamsAPI#isPowerAvailable()} returns {@code true} and
+     * {@link TeamsAPI#getPowerService()} returns the registered provider.
+     */
+    @Test
+    void registerPowerProvider_makesPowerServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(plugin, mockPower);
+
+        assertTrue(TeamsAPI.isPowerAvailable());
+        assertEquals(mockPower, TeamsAPI.getPowerService());
+    }
+
+    /**
+     * unregisterPowerProvider_makesPowerServiceUnavailable verifies that after
+     * unregistering a power provider, {@link TeamsAPI#isPowerAvailable()} returns
+     * {@code false}.
+     */
+    @Test
+    void unregisterPowerProvider_makesPowerServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(plugin, mockPower);
+        TeamsAPI.unregisterPowerProvider(mockPower);
+
+        assertFalse(TeamsAPI.isPowerAvailable());
+    }
+
+    /**
+     * registerPowerProvider_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin does not register anything.
+     */
+    @Test
+    void registerPowerProvider_withNullPlugin_doesNotRegister() {
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(null, mockPower);
+
+        assertFalse(TeamsAPI.isPowerAvailable());
+    }
+
+    /**
+     * registerPowerProvider_withNullProvider_doesNotRegister verifies that passing a
+     * {@code null} provider does not register anything.
+     */
+    @Test
+    void registerPowerProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerPowerProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isPowerAvailable());
+    }
+
+    /**
+     * unregisterPowerProvider_withNull_doesNotThrow verifies that passing {@code null}
+     * to {@link TeamsAPI#unregisterPowerProvider(TeamsPowerService)} does not throw.
+     */
+    @Test
+    void unregisterPowerProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterPowerProvider(null);
+        // No exception expected
+    }
+
+    /**
+     * registerPowerProvider_withPriority_registersCorrectly verifies that the overload
+     * accepting a {@link org.bukkit.plugin.ServicePriority} registers the power provider
+     * successfully.
+     */
+    @Test
+    void registerPowerProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(plugin, mockPower,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isPowerAvailable());
+        assertEquals(mockPower, TeamsAPI.getPowerService());
+    }
+
+    /**
+     * registerPowerProvider_withPriority_withNullPriority_doesNotRegister verifies that
+     * passing a {@code null} priority does not register anything.
+     */
+    @Test
+    void registerPowerProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(plugin, mockPower, null);
+
+        assertFalse(TeamsAPI.isPowerAvailable());
+    }
+
+    /**
+     * powerService_isIndependentOfTeamsService verifies that registering only a power
+     * provider does not affect {@link TeamsAPI#isAvailable()}, and vice versa.
+     */
+    @Test
+    void powerService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerService mockPower = mock(TeamsPowerService.class);
+
+        TeamsAPI.registerPowerProvider(plugin, mockPower);
+
+        assertTrue(TeamsAPI.isPowerAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}


### PR DESCRIPTION
**Claim service**

| Method | Description |
|--------|-------------|
| `getClaimService()` | Returns the active `TeamsClaimService`, or `null` if none is registered. |
| `isClaimAvailable()` | Returns `true` when a claim provider is registered. |
| `registerClaimProvider(plugin, service)` | Registers a claim provider at `ServicePriority.Normal`. |
| `registerClaimProvider(plugin, service, priority)` | Registers a claim provider at the given priority. |
| `unregisterClaimProvider(service)` | Unregisters a claim provider from Bukkit's ServicesManager. |

**Power service**

| Method | Description |
|--------|-------------|
| `getPowerService()` | Returns the active `TeamsPowerService`, or `null` if none is registered. |
| `isPowerAvailable()` | Returns `true` when a power provider is registered. |
| `registerPowerProvider(plugin, service)` | Registers a power provider at `ServicePriority.Normal`. |
| `registerPowerProvider(plugin, service, priority)` | Registers a power provider at the given priority. |
| `unregisterPowerProvider(service)` | Unregisters a power provider from Bukkit's ServicesManager. |