### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,14 @@ jobs:
           REDIS_PORT: 6379
         run: mvn -B -ntp verify
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: teams-api/target/site/jacoco/jacoco.xml
+          flags: unittests
+          fail_ci_if_error: true
+
   package:
     name: Package Plugin
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+flags:
+  unittests:
+    paths:
+      - teams-api/src/main/java/
+    carryforward: false


### PR DESCRIPTION
- Upload JaCoCo XML report from teams-api after verify step
- Add codecov.yml with project/patch status checks and unittests flag