### PR TITLE
Subcommand API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `teamsapi.use` permission (default: `true`) — basic access to `/teamsapi`.
 - `teamsapi.status` permission (default: `true`) — access to `/teamsapi status`.
 
+### Changed
+
+- `/teamsapi` now requires `teamsapi.use`; senders without it receive a permission
+  error instead of the help message.
+- `/teamsapi status` now requires `teamsapi.status`.
+- `/teamsapi info` now requires `teamsapi.admin`.
+- `/teamsapi help` (and the bare `/teamsapi`) only lists subcommands that the
+  sender has permission to execute.
+
 ## [1.5.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.0]
+
+### Added
+
+- `TeamsSubcommand` interface: providers can register custom subcommands under
+  `/teamsapi <name>` via `TeamsAPI.registerSubcommand(plugin, subcommand)`. Each
+  subcommand declares a `getName()`, `getDescription()`, optional `getPermission()`,
+  and `execute(CommandSender, String[])`.
+- `TeamsAPI.registerSubcommand(plugin, subcommand)` — registers via Bukkit ServicesManager.
+- `TeamsAPI.unregisterSubcommand(subcommand)` — unregisters; call from `onDisable`.
+- `TeamsAPI.getSubcommands()` — returns all registered subcommands as a snapshot.
+- `/teamsapi status` — player-accessible (no admin permission required); shows the
+  active provider, team count, and which optional services (invites, warps, claims,
+  power) are registered.
+- `/teamsapi info` now shows all five registered service types (TeamsService,
+  InviteService, WarpService, ClaimService, PowerService) and the registered
+  subcommand count.
+- `teamsapi.use` permission (default: `true`) — basic access to `/teamsapi`.
+- `teamsapi.status` permission (default: `true`) — access to `/teamsapi status`.
+
 ## [1.5.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.5.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.4.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 ```
 
@@ -206,6 +206,62 @@ public void onDisable() {
 }
 ```
 
+### Custom subcommands
+
+Any plugin can register a `TeamsSubcommand` via `TeamsAPI.registerSubcommand()`. Team
+plugins call `TeamsAPI.getSubcommands()` in their own command executor to dispatch them,
+allowing third-party plugins to extend the team plugin's command tree without any direct
+coupling between plugins.
+
+Extend `AbstractTeamsSubcommand` (recommended) or implement `TeamsSubcommand` directly:
+
+```java
+public class StatsSubcommand extends AbstractTeamsSubcommand {
+    public StatsSubcommand() {
+        super("stats", "Show faction statistics.", "myfactions.stats");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        // handle the command
+        return true; // return false to trigger the usage hint
+    }
+}
+
+// In onEnable:
+TeamsAPI.registerSubcommand(this, new StatsSubcommand());
+
+// In onDisable:
+TeamsAPI.unregisterSubcommand(statsSubcommand);
+```
+
+Team plugins dispatch registered subcommands inside their own command executor:
+
+```java
+for (TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+    if (sub.getName().equalsIgnoreCase(args[0])) {
+        String perm = sub.getPermission();
+        if (perm != null && !sender.hasPermission(perm)) {
+            sender.sendMessage("You do not have permission.");
+            return true;
+        }
+        if (!sub.execute(sender, args)) {
+            sender.sendMessage("Usage: " + sub.getUsage());
+        }
+        return true;
+    }
+}
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getName()` | `String` | Matched case-insensitively against `args[0]` |
+| `getDescription()` | `String` | Optional description for help output |
+| `getPermission()` | `String` | Required permission, or `null` for no check |
+| `execute(sender, args)` | `boolean` | Called when dispatched; return `false` to show usage |
+| `getUsage()` | `String` | Usage hint sent when `execute` returns `false` |
+| `tabComplete(sender, args)` | `List<String>` | Tab-completion suggestions; default: empty list |
+
 ### Events
 
 Provider events extend `TeamEvent`. Core events are cancellable:
@@ -226,6 +282,11 @@ public void onWarpSet(TeamWarpSetEvent event) {
 @EventHandler
 public void onClaim(TeamClaimEvent event) {
     // Cancel to block the claim
+}
+
+@EventHandler
+public void onUnclaim(TeamUnclaimEvent event) {
+    // Cancel to block the unclaim
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,26 @@ Entry point for all API interactions. All methods are static.
 | `registerPowerProvider(plugin, service, priority)` | Registers a power provider at the given priority. |
 | `unregisterPowerProvider(service)` | Unregisters a power provider from Bukkit's ServicesManager. |
 
+**Custom subcommands**
+
+| Method | Description |
+|--------|-------------|
+| `getSubcommands()` | Returns all currently registered `TeamsSubcommand` implementations. Never `null`; empty if none are registered. |
+| `registerSubcommand(plugin, subcommand)` | Registers a custom subcommand under `/teamsapi` via Bukkit's ServicesManager. Silently ignored if either argument is `null`. |
+| `unregisterSubcommand(subcommand)` | Unregisters a custom subcommand. Call from your plugin's `onDisable`. Silently ignored if `null`. |
+
+## `TeamsSubcommand` (interface)
+
+Providers implement this interface to inject custom subcommands into the `/teamsapi`
+command tree. Register via `TeamsAPI.registerSubcommand(plugin, subcommand)`.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getName()` | `String` | The subcommand name matched case-insensitively against the first argument of `/teamsapi`. Must be unique among all registered subcommands. |
+| `getDescription()` | `String` | Short description shown in `/teamsapi help`. |
+| `getPermission()` | `String` | Permission node required to use this subcommand, or `null` if no permission check is performed. |
+| `execute(sender, args)` | `boolean` | Called when a sender runs `/teamsapi <name> [args...]`. `args[0]` is the subcommand name. Returns `true` if the command was handled, `false` to print usage. |
+
 ## `TeamsService` (interface)
 
 Implemented by team plugins. Obtained via `TeamsAPI.getService()`.

--- a/docs/consumer-subcommands.md
+++ b/docs/consumer-subcommands.md
@@ -1,0 +1,159 @@
+---
+title: Registering Subcommands
+nav_order: 5
+parent: Developer Guide
+description: "How to implement and register a TeamsSubcommand so team plugins dispatch it in their own command handler"
+---
+
+# Registering Subcommands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+Any plugin can register a custom subcommand with TeamsAPI. Once registered, team
+plugins that implement the dispatch hook (see
+[Custom Subcommands](provider-subcommands)) will include your subcommand in their
+own command tree — for example as `/factions stats` or `/clans stats`.
+
+This is the same Vault-style decoupling: your plugin registers, the team plugin
+dispatches. Neither needs to know about the other.
+
+## 1. Declare the soft-dependency
+
+```yaml
+# plugin.yml
+softdepend:
+  - TeamsAPI
+```
+
+Use `softdepend` so your plugin still loads on servers without TeamsAPI. Guard the
+registration call as shown in [section 3](#3-register-and-unregister).
+
+## 2. Implement `TeamsSubcommand`
+
+### Option A — extend `AbstractTeamsSubcommand` (recommended)
+
+Pass name, description, and (optionally) permission to the constructor; override
+only what you need:
+
+```java
+import com.skyblockexp.teamsapi.api.AbstractTeamsSubcommand;
+
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+public class StatsSubcommand extends AbstractTeamsSubcommand {
+
+    public StatsSubcommand() {
+        super("stats", "Show your team statistics.", "myplugin.stats");
+    }
+
+    @Override
+    public String getUsage() {
+        return "stats [player]";
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String[] args) {
+        // args[0] is "stats"; additional arguments start at args[1]
+        sender.sendMessage("Stats: ...");
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String[] args) {
+        if (args.length == 2) {
+            return List.of("player1", "player2");
+        }
+        return List.of();
+    }
+}
+```
+
+`getName()`, `getDescription()`, and `getPermission()` are handled by the
+constructor. Override `getUsage()` and `tabComplete()` as needed.
+
+### Option B — implement `TeamsSubcommand` directly
+
+Use this when you need dynamic behaviour such as a runtime-computed name or
+permission:
+
+```java
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
+
+import org.bukkit.command.CommandSender;
+
+public class StatsSubcommand implements TeamsSubcommand {
+
+    @Override
+    public String getName() { return "stats"; }
+
+    @Override
+    public String getDescription() { return "Show your team statistics."; }
+
+    @Override
+    public String getPermission() { return "myplugin.stats"; }
+
+    @Override
+    public String getUsage() { return "stats [player]"; }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String[] args) {
+        sender.sendMessage("Stats: ...");
+        return true;
+    }
+}
+```
+
+## 3. Register and unregister
+
+Register in `onEnable` and unregister in `onDisable`. Bukkit's ServicesManager
+also unregisters all services when a plugin is unloaded, but calling
+`unregisterSubcommand` explicitly is good practice.
+
+```java
+import com.skyblockexp.teamsapi.api.TeamsAPI;
+
+private final StatsSubcommand statsSubcommand = new StatsSubcommand();
+
+@Override
+public void onEnable() {
+    if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
+        final boolean alreadyRegistered = TeamsAPI.getSubcommands().stream()
+                .anyMatch(s -> s.getName().equalsIgnoreCase(statsSubcommand.getName()));
+        if (!alreadyRegistered) {
+            TeamsAPI.registerSubcommand(this, statsSubcommand);
+        }
+    }
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterSubcommand(statsSubcommand);
+}
+```
+
+The duplicate guard prevents double-registration if your plugin is reloaded
+without a full server restart (e.g. via PlugMan).
+
+## 4. `TeamsSubcommand` interface contract
+
+| Method | Returns | Contract |
+|--------|---------|----------|
+| `getName()` | `String` | Case-insensitive match against `args[0]` in the provider's dispatch. Use a unique, stable name. |
+| `getDescription()` | `String` | Short description shown in the team plugin's help output. |
+| `getPermission()` | `String` | Permission node checked before `execute()` is called. `null` means no check. |
+| `execute(sender, args)` | `boolean` | Return `true` if handled. Return `false` to trigger the usage hint. `args[0]` is the subcommand name. |
+| `getUsage()` | `String` | Usage hint shown when `execute()` returns `false`. Default: the subcommand name. Override to include expected arguments, e.g. `"stats [player]"`. |
+| `tabComplete(sender, args)` | `List<String>` | Tab-completion suggestions. Default: empty list. |
+
+## See also
+
+- [Custom Subcommands (provider)](provider-subcommands): how team plugins implement
+  the dispatch hook
+- [API Reference](api): full interface and model documentation

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -229,49 +229,23 @@ private void handlePowerCommand(Player player, UUID teamId) {
 ### 8. Register a custom subcommand (providers)
 
 Providers can expose additional commands under `/teamsapi <name>` without
-shipping a separate Bukkit command. Implement `TeamsSubcommand` and register it
-in `onEnable`; unregister in `onDisable` (Bukkit's `ServicesManager` unregisters
-automatically when the plugin unloads, but explicit cleanup is best practice).
+shipping a separate Bukkit command. See the dedicated
+[Custom Subcommands](provider-subcommands) guide for the full walkthrough,
+permission behaviour, and a complete working example.
+
+Quick-start:
 
 ```java
-public class FactionsSubcommand implements TeamsSubcommand {
-
-    @Override
-    public String getName() { return "factions"; }
-
-    @Override
-    public String getDescription() { return "Show Factions-specific team stats."; }
-
-    @Override
-    public String getPermission() { return null; } // no restriction
-
-    @Override
-    public boolean execute(CommandSender sender, String[] args) {
-        sender.sendMessage("Factions info goes here.");
-        return true;
-    }
-}
-```
-
-In your plugin main class:
-
-```java
-private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
-
 @Override
 public void onEnable() {
-    TeamsAPI.registerSubcommand(this, factionsSubcommand);
+    TeamsAPI.registerSubcommand(this, new StatsSubcommand());
 }
 
 @Override
 public void onDisable() {
-    TeamsAPI.unregisterSubcommand(factionsSubcommand);
+    TeamsAPI.unregisterSubcommand(statsSubcommand);
 }
 ```
-
-Players can then run `/teamsapi factions` and the call is routed to your
-implementation. The subcommand also appears in `/teamsapi help` with the
-description you provided.
 
 ## Events
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -226,6 +226,53 @@ private void handlePowerCommand(Player player, UUID teamId) {
 }
 ```
 
+### 8. Register a custom subcommand (providers)
+
+Providers can expose additional commands under `/teamsapi <name>` without
+shipping a separate Bukkit command. Implement `TeamsSubcommand` and register it
+in `onEnable`; unregister in `onDisable` (Bukkit's `ServicesManager` unregisters
+automatically when the plugin unloads, but explicit cleanup is best practice).
+
+```java
+public class FactionsSubcommand implements TeamsSubcommand {
+
+    @Override
+    public String getName() { return "factions"; }
+
+    @Override
+    public String getDescription() { return "Show Factions-specific team stats."; }
+
+    @Override
+    public String getPermission() { return null; } // no restriction
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        sender.sendMessage("Factions info goes here.");
+        return true;
+    }
+}
+```
+
+In your plugin main class:
+
+```java
+private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
+
+@Override
+public void onEnable() {
+    TeamsAPI.registerSubcommand(this, factionsSubcommand);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterSubcommand(factionsSubcommand);
+}
+```
+
+Players can then run `/teamsapi factions` and the call is routed to your
+implementation. The subcommand also appears in `/teamsapi help` with the
+description you provided.
+
 ## Events
 
 Providers are encouraged to fire events before performing state changes. Whether

--- a/docs/provider-invites.md
+++ b/docs/provider-invites.md
@@ -100,4 +100,5 @@ softdepend:
 
 - [Team Provider](../provider-teams): implementing the core `TeamsService`
 - [Warp Provider](../provider-warps): adding optional warp support
+- [Custom Subcommands](../provider-subcommands): injecting subcommands into `/teamsapi`
 - [API Reference](../api): full interface and model documentation

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -2,7 +2,7 @@
 title: Custom Subcommands
 nav_order: 4
 parent: Developer Guide
-description: "How to inject custom subcommands into /teamsapi using TeamsSubcommand"
+description: "How to dispatch TeamsSubcommand registrations inside your team plugin's own command handler"
 ---
 
 # Custom Subcommands
@@ -14,254 +14,199 @@ description: "How to inject custom subcommands into /teamsapi using TeamsSubcomm
 1. TOC
 {:toc}
 
-`TeamsSubcommand` lets any provider plugin inject additional subcommands into the
-`/teamsapi` command tree without shipping a separate Bukkit command. Each registered
-subcommand appears in `/teamsapi help` and is dispatched automatically by the
-TeamsAPI plugin when a player runs `/teamsapi <name>`.
+The custom subcommand system lets any third-party plugin extend your team plugin's
+command tree without you knowing about it at compile time. Your team plugin adds a
+dispatch loop inside its own `CommandExecutor` that checks `TeamsAPI.getSubcommands()`
+after handling its own built-in subcommands. When a match is found the registered
+`TeamsSubcommand` is called directly — in your command, under your permission system.
 
-This is useful when a provider wants to expose commands that players already know.
-For example, a Factions plugin that normally uses `/f` can register `f` as a
-subcommand so players run `/teamsapi f [args...]` — one familiar short alias,
-no extra top-level command registration required.
+This is the same Vault-style decoupling that makes `TeamsService` work: your plugin
+dispatches, other plugins register. Neither needs to know about the other.
 
-## 1. Implement `TeamsSubcommand`
-
-### Option A — extend `AbstractTeamsSubcommand` (recommended)
-
-`AbstractTeamsSubcommand` handles the boilerplate for you. Pass name, description,
-and (optionally) permission to the constructor; override only what you need.
-
-```java
-import com.skyblockexp.teamsapi.api.AbstractTeamsSubcommand;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
-public class FactionsSubcommand extends AbstractTeamsSubcommand {
-
-    public FactionsSubcommand() {
-        super("f", "Factions commands (alias: /f).", "myfactions.use");
-    }
-
-    @Override
-    public String getUsage() {
-        return "/teamsapi f <help|stats|top> [args...]";
-    }
-
-    @Override
-    public boolean execute(final CommandSender sender, final String[] args) {
-        if (args.length < 2) {
-            return false; // TeamsAPI prints getUsage()
-        }
-        if (!(sender instanceof Player)) {
-            sender.sendMessage("This command can only be used by players.");
-            return true;
-        }
-        return handleSubcommand((Player) sender, args);
-    }
-
-    private boolean handleSubcommand(final Player player, final String[] args) {
-        player.sendMessage("Factions: " + args[1]);
-        return true;
-    }
-}
-```
-
-`getName()`, `getDescription()`, and `getPermission()` are already implemented.
-`getUsage()` and `tabComplete()` have sensible defaults — override either as needed.
-
-### Option B — implement `TeamsSubcommand` directly
-
-Use this when you need full control (e.g. dynamic name resolution or a
-permission that changes at runtime).
-
-```java
-import com.skyblockexp.teamsapi.api.TeamsSubcommand;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
-public class FactionsSubcommand implements TeamsSubcommand {
-
-    @Override
-    public String getName() { return "f"; }
-
-    @Override
-    public String getDescription() { return "Factions commands (alias: /f)."; }
-
-    @Override
-    public String getPermission() { return "myfactions.use"; }
-
-    @Override
-    public String getUsage() { return "/teamsapi f <help|stats|top> [args...]"; }
-
-    @Override
-    public boolean execute(final CommandSender sender, final String[] args) {
-        if (args.length < 2) {
-            return false; // TeamsAPI prints getUsage()
-        }
-        if (!(sender instanceof Player)) {
-            sender.sendMessage("This command can only be used by players.");
-            return true;
-        }
-        sender.sendMessage("Factions: " + args[1]);
-        return true;
-    }
-}
-```
-
-### Interface contract
-
-| Method | Returns | Contract |
-|--------|---------|----------|
-| `getName()` | `String` | Case-insensitive match against `args[0]`. Must be stable across reloads. Use your plugin's familiar short name (e.g. `"f"` for a Factions plugin). |
-| `getDescription()` | `String` | Short, single-line description for help output. |
-| `getPermission()` | `String` | Permission node, or `null` if anyone with `teamsapi.use` may run it. |
-| `getUsage()` | `String` | Usage string sent to the sender when `execute()` returns `false`. Default: `"/teamsapi <name>"`. Override to include expected arguments. |
-| `execute(sender, args)` | `boolean` | Return `true` if the command was handled (even on error). Return `false` to let TeamsAPI print the `getUsage()` hint. `args[0]` is always the subcommand name. |
-| `tabComplete(sender, args)` | `List<String>` | Tab-completion suggestions. Default returns an empty list. |
-
-### Permission behaviour
-
-If `getPermission()` returns a non-null value, TeamsAPI checks
-`sender.hasPermission(permission)` before calling `execute`. A sender without
-the permission receives a generic denial message and the subcommand is not
-dispatched. The subcommand is also hidden from `/teamsapi help` for that sender.
-
-If `getPermission()` returns `null`, the subcommand is accessible to any sender
-who has `teamsapi.use` (the base permission, default `true`).
-
-## 2. Register and unregister
-
-Register in `onEnable`, unregister in `onDisable`. Bukkit's ServicesManager
-also unregisters all services for a plugin automatically when it unloads, but
-explicit cleanup is best practice.
-
-```java
-private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
-
-@Override
-public void onEnable() {
-    TeamsAPI.registerSubcommand(this, factionsSubcommand);
-}
-
-@Override
-public void onDisable() {
-    TeamsAPI.unregisterSubcommand(factionsSubcommand);
-}
-```
-
-Players can then run `/teamsapi f <subcommand>` and the call is routed to your
-implementation.
-
-`registerSubcommand` uses `ServicePriority.Normal`. If two plugins register a
-subcommand with the same name, both are registered; TeamsAPI dispatches to the
-first match it finds when iterating `getSubcommands()` (highest-priority first
-by ServicesManager ordering). Prefer unique names to avoid conflicts.
-
-### Registering multiple subcommands
-
-```java
-private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
-private final ClansSubcommand clansSubcommand = new ClansSubcommand();
-
-@Override
-public void onEnable() {
-    TeamsAPI.registerSubcommand(this, factionsSubcommand); // /teamsapi f
-    TeamsAPI.registerSubcommand(this, clansSubcommand);   // /teamsapi clans
-}
-
-@Override
-public void onDisable() {
-    TeamsAPI.unregisterSubcommand(factionsSubcommand);
-    TeamsAPI.unregisterSubcommand(clansSubcommand);
-}
-```
-
-## 3. Declare the soft-dependency in `plugin.yml`
+## 1. Declare the soft-dependency
 
 ```yaml
+# plugin.yml
 softdepend:
   - TeamsAPI
 ```
 
-Use `softdepend` (not `depend`) so your plugin can still load on servers that
-do not have TeamsAPI installed. Guard the registration call with a null check or
-a `isAvailable` guard if TeamsAPI is optional:
+Use `softdepend` so your plugin loads on servers without TeamsAPI. The dispatch
+loop is a no-op when `getSubcommands()` returns an empty collection, but you still
+need to guard the `TeamsAPI` class reference itself (see
+[section 4](#4-guard-when-teamsapi-is-absent)).
+
+## 2. Add the dispatch loop to your `CommandExecutor`
+
+After handling your plugin's own subcommands, fall through to
+`TeamsAPI.getSubcommands()`:
 
 ```java
-@Override
-public void onEnable() {
-    if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
-        TeamsAPI.registerSubcommand(this, factionsSubcommand);
-    }
-}
-```
-
-## 4. Full working example
-
-A Factions plugin that registers `/teamsapi f` so players can type `/teamsapi f
-<subcommand>` using the same short alias they already know:
-
-```java
-import com.skyblockexp.teamsapi.api.AbstractTeamsSubcommand;
 import com.skyblockexp.teamsapi.api.TeamsAPI;
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
-public final class MyFactionsPlugin extends JavaPlugin {
+public class FactionsCommandExecutor implements CommandExecutor {
 
-    private final AbstractTeamsSubcommand fSubcommand =
-        new AbstractTeamsSubcommand("f", "Factions commands.", "myfactions.use") {
+    @Override
+    public boolean onCommand(final CommandSender sender, final Command command,
+            final String label, final String[] args) {
+        if (args.length == 0) {
+            showHelp(sender, label);
+            return true;
+        }
 
-            @Override
-            public String getUsage() {
-                return "/teamsapi f <help|stats|top> [args...]";
-            }
+        // Handle your own built-in subcommands first
+        switch (args[0].toLowerCase()) {
+            case "create":
+                return handleCreate(sender, args);
+            case "disband":
+                return handleDisband(sender, args);
+            // ...
+            default:
+                break;
+        }
 
-            @Override
-            public boolean execute(final CommandSender sender, final String[] args) {
-                if (!(sender instanceof Player)) {
-                    sender.sendMessage("Players only.");
+        // Fall through to any registered TeamsSubcommand
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    sender.sendMessage("You do not have permission to use this command.");
                     return true;
                 }
-                if (args.length < 2) {
-                    return false; // TeamsAPI prints getUsage()
+                if (!sub.execute(sender, args)) {
+                    sender.sendMessage("Usage: " + sub.getUsage());
                 }
-                // Dispatch to your own subcommand handler.
-                return MyFactionsPlugin.this.dispatch((Player) sender, args);
+                return true;
             }
-
-            @Override
-            public java.util.List<String> tabComplete(
-                    final CommandSender sender, final String[] args) {
-                if (args.length == 2) {
-                    return java.util.List.of("help", "stats", "top");
-                }
-                return java.util.Collections.emptyList();
-            }
-        };
-
-    @Override
-    public void onEnable() {
-        if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
-            TeamsAPI.registerSubcommand(this, fSubcommand);
         }
-    }
 
-    @Override
-    public void onDisable() {
-        TeamsAPI.unregisterSubcommand(fSubcommand);
-    }
-
-    private boolean dispatch(final Player player, final String[] args) {
-        player.sendMessage("Factions " + args[1] + ": ...");
+        sender.sendMessage("Unknown subcommand. Use /" + label + " help.");
         return true;
     }
 }
 ```
+
+`args` is passed to `execute()` unchanged. The registered subcommand receives
+`args[0]` as its own name and its arguments starting at `args[1]`.
+
+## 3. Add tab-complete dispatch
+
+Wire the same lookup into your `TabCompleter`:
+
+```java
+import com.skyblockexp.teamsapi.api.TeamsAPI;
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+public class FactionsTabCompleter implements TabCompleter {
+
+    @Override
+    public List<String> onTabComplete(final CommandSender sender, final Command command,
+            final String label, final String[] args) {
+        if (args.length == 1) {
+            // Merge your own subcommand names with registered TeamsSubcommand names
+            final List<String> suggestions = new ArrayList<>(List.of("create", "disband"));
+            for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+                final String perm = sub.getPermission();
+                if (perm == null || sender.hasPermission(perm)) {
+                    suggestions.add(sub.getName());
+                }
+            }
+            final String prefix = args[0].toLowerCase();
+            suggestions.removeIf(s -> !s.toLowerCase().startsWith(prefix));
+            return suggestions;
+        }
+        if (args.length > 1) {
+            // Delegate to the matched subcommand's tab-complete
+            for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+                if (sub.getName().equalsIgnoreCase(args[0])) {
+                    final String perm = sub.getPermission();
+                    if (perm != null && !sender.hasPermission(perm)) {
+                        return Collections.emptyList();
+                    }
+                    final List<String> completions = sub.tabComplete(sender, args);
+                    return completions != null ? completions : Collections.emptyList();
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+}
+```
+
+## 4. Guard when TeamsAPI is absent
+
+If TeamsAPI is a soft-dependency, wrap the dispatch loop with a null check so the
+`TeamsAPI` class reference is only evaluated when the plugin is actually loaded:
+
+```java
+if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
+    for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+        // ...
+    }
+}
+```
+
+`TeamsAPI.getSubcommands()` returns an empty collection when no subcommands are
+registered, so the loop itself is safe. The guard is only needed to prevent a
+`ClassNotFoundException` on servers where `TeamsAPI.jar` is not present at all.
+
+## 5. Display registered subcommands in your help output
+
+You can include registered subcommands in your `/factions help` listing:
+
+```java
+private void showHelp(final CommandSender sender, final String label) {
+    sender.sendMessage("=== /" + label + " help ===");
+    sender.sendMessage("/" + label + " create <name>  —  Create a faction");
+    sender.sendMessage("/" + label + " disband  —  Disband your faction");
+
+    // Third-party subcommands registered via TeamsAPI
+    for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+        final String perm = sub.getPermission();
+        if (perm == null || sender.hasPermission(perm)) {
+            sender.sendMessage("/" + label + " " + sub.getName()
+                    + "  —  " + sub.getDescription());
+        }
+    }
+}
+```
+
+## 6. `TeamsSubcommand` interface contract
+
+Third-party plugins that want to extend your command tree implement
+`TeamsSubcommand` (or extend `AbstractTeamsSubcommand`) and call
+`TeamsAPI.registerSubcommand()`. Your plugin never needs to import or reference
+those plugins.
+
+| Method | Returns | Contract |
+|--------|---------|---------|
+| `getName()` | `String` | Matched case-insensitively against `args[0]`. |
+| `getDescription()` | `String` | Short description; use it in your help output if you wish. |
+| `getPermission()` | `String` | Permission node to check before dispatching, or `null` for no check. |
+| `execute(sender, args)` | `boolean` | Return `true` if handled (including on error). Return `false` to trigger the usage hint. `args[0]` is the subcommand name. |
+| `getUsage()` | `String` | Usage string sent to the sender when `execute()` returns `false`. |
+| `tabComplete(sender, args)` | `List<String>` | Completion suggestions; default returns an empty list. |
+
+### Priority and name conflicts
+
+`registerSubcommand` uses `ServicePriority.Normal`. If two plugins register a
+subcommand with the same name, the dispatch loop calls the one with the highest
+ServicesManager priority first. Prefer unique names to avoid conflicts. Your own
+built-in subcommands take priority because the loop runs only after your `switch`
+(or equivalent) has already had first pick.
 
 ## See also
 

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -26,6 +26,55 @@ no extra top-level command registration required.
 
 ## 1. Implement `TeamsSubcommand`
 
+### Option A — extend `AbstractTeamsSubcommand` (recommended)
+
+`AbstractTeamsSubcommand` handles the boilerplate for you. Pass name, description,
+and (optionally) permission to the constructor; override only what you need.
+
+```java
+import com.skyblockexp.teamsapi.api.AbstractTeamsSubcommand;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class FactionsSubcommand extends AbstractTeamsSubcommand {
+
+    public FactionsSubcommand() {
+        super("f", "Factions commands (alias: /f).", "myfactions.use");
+    }
+
+    @Override
+    public String getUsage() {
+        return "/teamsapi f <help|stats|top> [args...]";
+    }
+
+    @Override
+    public boolean execute(final CommandSender sender, final String[] args) {
+        if (args.length < 2) {
+            return false; // TeamsAPI prints getUsage()
+        }
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        return handleSubcommand((Player) sender, args);
+    }
+
+    private boolean handleSubcommand(final Player player, final String[] args) {
+        player.sendMessage("Factions: " + args[1]);
+        return true;
+    }
+}
+```
+
+`getName()`, `getDescription()`, and `getPermission()` are already implemented.
+`getUsage()` and `tabComplete()` have sensible defaults — override either as needed.
+
+### Option B — implement `TeamsSubcommand` directly
+
+Use this when you need full control (e.g. dynamic name resolution or a
+permission that changes at runtime).
+
 ```java
 import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 
@@ -35,50 +84,27 @@ import org.bukkit.entity.Player;
 public class FactionsSubcommand implements TeamsSubcommand {
 
     @Override
-    public String getName() {
-        // Players type /teamsapi f [args...]
-        // Matched case-insensitively against args[0] of /teamsapi.
-        return "f";
-    }
+    public String getName() { return "f"; }
 
     @Override
-    public String getDescription() {
-        // Shown next to the subcommand name in /teamsapi help.
-        return "Factions commands (alias: /f).";
-    }
+    public String getDescription() { return "Factions commands (alias: /f)."; }
 
     @Override
-    public String getPermission() {
-        // Return null for no permission check.
-        // Return a permission node string to restrict access.
-        return "myfactions.use";
-    }
+    public String getPermission() { return "myfactions.use"; }
 
     @Override
-    public String getUsage() {
-        // Shown to the sender when execute() returns false.
-        return "/teamsapi f <subcommand> [args...]";
-    }
+    public String getUsage() { return "/teamsapi f <help|stats|top> [args...]"; }
 
     @Override
-    public boolean execute(CommandSender sender, String[] args) {
-        // args[0] is "f".
-        // args[1], args[2], ... are the subcommand and its arguments.
+    public boolean execute(final CommandSender sender, final String[] args) {
         if (args.length < 2) {
-            sender.sendMessage("Usage: " + getUsage());
-            return false; // TeamsAPI will also print the usage hint
+            return false; // TeamsAPI prints getUsage()
         }
         if (!(sender instanceof Player)) {
             sender.sendMessage("This command can only be used by players.");
             return true;
         }
-        // Delegate to your own subcommand dispatcher here.
-        return handleSubcommand((Player) sender, args);
-    }
-
-    private boolean handleSubcommand(Player player, String[] args) {
-        // args[1] is the Factions sub-action.
-        player.sendMessage("Factions: " + args[1]);
+        sender.sendMessage("Factions: " + args[1]);
         return true;
     }
 }

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -1,0 +1,207 @@
+---
+title: Custom Subcommands
+nav_order: 4
+parent: Developer Guide
+description: "How to inject custom subcommands into /teamsapi using TeamsSubcommand"
+---
+
+# Custom Subcommands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+`TeamsSubcommand` lets any provider plugin inject additional subcommands into the
+`/teamsapi` command tree without shipping a separate Bukkit command. Each registered
+subcommand appears in `/teamsapi help` and is dispatched automatically by the
+TeamsAPI plugin when a player runs `/teamsapi <name>`.
+
+This is useful when a provider wants to expose plugin-specific operations (for
+example `/teamsapi factions stats` or `/teamsapi clans invite`) through a single
+shared command rather than registering its own top-level command.
+
+## 1. Implement `TeamsSubcommand`
+
+```java
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class StatsSubcommand implements TeamsSubcommand {
+
+    @Override
+    public String getName() {
+        // Matched case-insensitively against args[0] of /teamsapi.
+        // Must be unique among all registered subcommands.
+        return "stats";
+    }
+
+    @Override
+    public String getDescription() {
+        // Shown next to the subcommand name in /teamsapi help.
+        return "Show your faction statistics.";
+    }
+
+    @Override
+    public String getPermission() {
+        // Return null for no permission check.
+        // Return a permission node string to restrict access.
+        return "myfactions.stats";
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        // args[0] is the subcommand name ("stats").
+        // args[1], args[2], ... are additional arguments, if any.
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+        // ... your logic here ...
+        sender.sendMessage("Stats for " + sender.getName() + ": ...");
+        return true;
+    }
+}
+```
+
+### Interface contract
+
+| Method | Returns | Contract |
+|--------|---------|----------|
+| `getName()` | `String` | Case-insensitive match against `args[0]`. Must be stable across reloads. |
+| `getDescription()` | `String` | Short, single-line description for help output. |
+| `getPermission()` | `String` | Permission node, or `null` if anyone with `teamsapi.use` may run it. |
+| `execute(sender, args)` | `boolean` | Return `true` if the command was handled (even on error). Return `false` to print usage to the sender. `args[0]` is always the subcommand name. |
+
+### Permission behaviour
+
+If `getPermission()` returns a non-null value, TeamsAPI checks
+`sender.hasPermission(permission)` before calling `execute`. A sender without
+the permission receives a generic denial message and the subcommand is not
+dispatched. The subcommand is also hidden from `/teamsapi help` for that sender.
+
+If `getPermission()` returns `null`, the subcommand is accessible to any sender
+who has `teamsapi.use` (the base permission, default `true`).
+
+## 2. Register and unregister
+
+Register in `onEnable`, unregister in `onDisable`. Bukkit's ServicesManager
+also unregisters all services for a plugin automatically when it unloads, but
+explicit cleanup is best practice.
+
+```java
+private final StatsSubcommand statsSubcommand = new StatsSubcommand();
+
+@Override
+public void onEnable() {
+    TeamsAPI.registerSubcommand(this, statsSubcommand);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterSubcommand(statsSubcommand);
+}
+```
+
+`registerSubcommand` uses `ServicePriority.Normal`. If two plugins register a
+subcommand with the same name, both are registered; TeamsAPI dispatches to the
+first match it finds when iterating `getSubcommands()` (highest-priority first
+by ServicesManager ordering). Prefer unique names to avoid conflicts.
+
+### Registering multiple subcommands
+
+```java
+private final StatsSubcommand statsSubcommand = new StatsSubcommand();
+private final LeaderboardSubcommand lbSubcommand = new LeaderboardSubcommand();
+
+@Override
+public void onEnable() {
+    TeamsAPI.registerSubcommand(this, statsSubcommand);
+    TeamsAPI.registerSubcommand(this, lbSubcommand);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterSubcommand(statsSubcommand);
+    TeamsAPI.unregisterSubcommand(lbSubcommand);
+}
+```
+
+## 3. Declare the soft-dependency in `plugin.yml`
+
+```yaml
+softdepend:
+  - TeamsAPI
+```
+
+Use `softdepend` (not `depend`) so your plugin can still load on servers that
+do not have TeamsAPI installed. Guard the registration call with a null check or
+a `isAvailable` guard if TeamsAPI is optional:
+
+```java
+@Override
+public void onEnable() {
+    if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
+        TeamsAPI.registerSubcommand(this, statsSubcommand);
+    }
+}
+```
+
+## 4. Full working example
+
+```java
+import com.skyblockexp.teamsapi.api.TeamsAPI;
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class MyFactionsPlugin extends JavaPlugin {
+
+    private final TeamsSubcommand statsSubcommand = new TeamsSubcommand() {
+
+        @Override
+        public String getName() { return "fstats"; }
+
+        @Override
+        public String getDescription() { return "Show your faction stats."; }
+
+        @Override
+        public String getPermission() { return null; }
+
+        @Override
+        public boolean execute(final CommandSender sender, final String[] args) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("Players only.");
+                return true;
+            }
+            sender.sendMessage("Faction stats for " + sender.getName() + ": ...");
+            return true;
+        }
+    };
+
+    @Override
+    public void onEnable() {
+        if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
+            TeamsAPI.registerSubcommand(this, statsSubcommand);
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        TeamsAPI.unregisterSubcommand(statsSubcommand);
+    }
+}
+```
+
+## See also
+
+- [Team Provider](provider-teams): implementing the core `TeamsService`
+- [Invite Provider](provider-invites): adding optional invitation support
+- [Warp Provider](provider-warps): adding optional warp support
+- [API Reference](api): full interface and model documentation

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -200,6 +200,24 @@ those plugins.
 | `getUsage()` | `String` | Usage string sent to the sender when `execute()` returns `false`. |
 | `tabComplete(sender, args)` | `List<String>` | Completion suggestions; default returns an empty list. |
 
+### Guard against duplicate registration
+
+If your plugin can be reloaded (e.g. via PlugMan), `onEnable()` may run again
+while the previous registration is still active. Check before registering:
+
+```java
+@Override
+public void onEnable() {
+    if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
+        final boolean alreadyRegistered = TeamsAPI.getSubcommands().stream()
+                .anyMatch(s -> s.getName().equalsIgnoreCase(statsSubcommand.getName()));
+        if (!alreadyRegistered) {
+            TeamsAPI.registerSubcommand(this, statsSubcommand);
+        }
+    }
+}
+```
+
 ### Priority and name conflicts
 
 `registerSubcommand` uses `ServicePriority.Normal`. If two plugins register a

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -19,9 +19,10 @@ description: "How to inject custom subcommands into /teamsapi using TeamsSubcomm
 subcommand appears in `/teamsapi help` and is dispatched automatically by the
 TeamsAPI plugin when a player runs `/teamsapi <name>`.
 
-This is useful when a provider wants to expose plugin-specific operations (for
-example `/teamsapi factions stats` or `/teamsapi clans invite`) through a single
-shared command rather than registering its own top-level command.
+This is useful when a provider wants to expose commands that players already know.
+For example, a Factions plugin that normally uses `/f` can register `f` as a
+subcommand so players run `/teamsapi f [args...]` — one familiar short alias,
+no extra top-level command registration required.
 
 ## 1. Implement `TeamsSubcommand`
 
@@ -31,38 +32,53 @@ import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-public class StatsSubcommand implements TeamsSubcommand {
+public class FactionsSubcommand implements TeamsSubcommand {
 
     @Override
     public String getName() {
+        // Players type /teamsapi f [args...]
         // Matched case-insensitively against args[0] of /teamsapi.
-        // Must be unique among all registered subcommands.
-        return "stats";
+        return "f";
     }
 
     @Override
     public String getDescription() {
         // Shown next to the subcommand name in /teamsapi help.
-        return "Show your faction statistics.";
+        return "Factions commands (alias: /f).";
     }
 
     @Override
     public String getPermission() {
         // Return null for no permission check.
         // Return a permission node string to restrict access.
-        return "myfactions.stats";
+        return "myfactions.use";
+    }
+
+    @Override
+    public String getUsage() {
+        // Shown to the sender when execute() returns false.
+        return "/teamsapi f <subcommand> [args...]";
     }
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        // args[0] is the subcommand name ("stats").
-        // args[1], args[2], ... are additional arguments, if any.
+        // args[0] is "f".
+        // args[1], args[2], ... are the subcommand and its arguments.
+        if (args.length < 2) {
+            sender.sendMessage("Usage: " + getUsage());
+            return false; // TeamsAPI will also print the usage hint
+        }
         if (!(sender instanceof Player)) {
             sender.sendMessage("This command can only be used by players.");
             return true;
         }
-        // ... your logic here ...
-        sender.sendMessage("Stats for " + sender.getName() + ": ...");
+        // Delegate to your own subcommand dispatcher here.
+        return handleSubcommand((Player) sender, args);
+    }
+
+    private boolean handleSubcommand(Player player, String[] args) {
+        // args[1] is the Factions sub-action.
+        player.sendMessage("Factions: " + args[1]);
         return true;
     }
 }
@@ -72,10 +88,12 @@ public class StatsSubcommand implements TeamsSubcommand {
 
 | Method | Returns | Contract |
 |--------|---------|----------|
-| `getName()` | `String` | Case-insensitive match against `args[0]`. Must be stable across reloads. |
+| `getName()` | `String` | Case-insensitive match against `args[0]`. Must be stable across reloads. Use your plugin's familiar short name (e.g. `"f"` for a Factions plugin). |
 | `getDescription()` | `String` | Short, single-line description for help output. |
 | `getPermission()` | `String` | Permission node, or `null` if anyone with `teamsapi.use` may run it. |
-| `execute(sender, args)` | `boolean` | Return `true` if the command was handled (even on error). Return `false` to print usage to the sender. `args[0]` is always the subcommand name. |
+| `getUsage()` | `String` | Usage string sent to the sender when `execute()` returns `false`. Default: `"/teamsapi <name>"`. Override to include expected arguments. |
+| `execute(sender, args)` | `boolean` | Return `true` if the command was handled (even on error). Return `false` to let TeamsAPI print the `getUsage()` hint. `args[0]` is always the subcommand name. |
+| `tabComplete(sender, args)` | `List<String>` | Tab-completion suggestions. Default returns an empty list. |
 
 ### Permission behaviour
 
@@ -94,18 +112,21 @@ also unregisters all services for a plugin automatically when it unloads, but
 explicit cleanup is best practice.
 
 ```java
-private final StatsSubcommand statsSubcommand = new StatsSubcommand();
+private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
 
 @Override
 public void onEnable() {
-    TeamsAPI.registerSubcommand(this, statsSubcommand);
+    TeamsAPI.registerSubcommand(this, factionsSubcommand);
 }
 
 @Override
 public void onDisable() {
-    TeamsAPI.unregisterSubcommand(statsSubcommand);
+    TeamsAPI.unregisterSubcommand(factionsSubcommand);
 }
 ```
+
+Players can then run `/teamsapi f <subcommand>` and the call is routed to your
+implementation.
 
 `registerSubcommand` uses `ServicePriority.Normal`. If two plugins register a
 subcommand with the same name, both are registered; TeamsAPI dispatches to the
@@ -115,19 +136,19 @@ by ServicesManager ordering). Prefer unique names to avoid conflicts.
 ### Registering multiple subcommands
 
 ```java
-private final StatsSubcommand statsSubcommand = new StatsSubcommand();
-private final LeaderboardSubcommand lbSubcommand = new LeaderboardSubcommand();
+private final FactionsSubcommand factionsSubcommand = new FactionsSubcommand();
+private final ClansSubcommand clansSubcommand = new ClansSubcommand();
 
 @Override
 public void onEnable() {
-    TeamsAPI.registerSubcommand(this, statsSubcommand);
-    TeamsAPI.registerSubcommand(this, lbSubcommand);
+    TeamsAPI.registerSubcommand(this, factionsSubcommand); // /teamsapi f
+    TeamsAPI.registerSubcommand(this, clansSubcommand);   // /teamsapi clans
 }
 
 @Override
 public void onDisable() {
-    TeamsAPI.unregisterSubcommand(statsSubcommand);
-    TeamsAPI.unregisterSubcommand(lbSubcommand);
+    TeamsAPI.unregisterSubcommand(factionsSubcommand);
+    TeamsAPI.unregisterSubcommand(clansSubcommand);
 }
 ```
 
@@ -146,16 +167,19 @@ a `isAvailable` guard if TeamsAPI is optional:
 @Override
 public void onEnable() {
     if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
-        TeamsAPI.registerSubcommand(this, statsSubcommand);
+        TeamsAPI.registerSubcommand(this, factionsSubcommand);
     }
 }
 ```
 
 ## 4. Full working example
 
+A Factions plugin that registers `/teamsapi f` so players can type `/teamsapi f
+<subcommand>` using the same short alias they already know:
+
 ```java
+import com.skyblockexp.teamsapi.api.AbstractTeamsSubcommand;
 import com.skyblockexp.teamsapi.api.TeamsAPI;
-import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -163,38 +187,52 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public final class MyFactionsPlugin extends JavaPlugin {
 
-    private final TeamsSubcommand statsSubcommand = new TeamsSubcommand() {
+    private final AbstractTeamsSubcommand fSubcommand =
+        new AbstractTeamsSubcommand("f", "Factions commands.", "myfactions.use") {
 
-        @Override
-        public String getName() { return "fstats"; }
-
-        @Override
-        public String getDescription() { return "Show your faction stats."; }
-
-        @Override
-        public String getPermission() { return null; }
-
-        @Override
-        public boolean execute(final CommandSender sender, final String[] args) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage("Players only.");
-                return true;
+            @Override
+            public String getUsage() {
+                return "/teamsapi f <help|stats|top> [args...]";
             }
-            sender.sendMessage("Faction stats for " + sender.getName() + ": ...");
-            return true;
-        }
-    };
+
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage("Players only.");
+                    return true;
+                }
+                if (args.length < 2) {
+                    return false; // TeamsAPI prints getUsage()
+                }
+                // Dispatch to your own subcommand handler.
+                return MyFactionsPlugin.this.dispatch((Player) sender, args);
+            }
+
+            @Override
+            public java.util.List<String> tabComplete(
+                    final CommandSender sender, final String[] args) {
+                if (args.length == 2) {
+                    return java.util.List.of("help", "stats", "top");
+                }
+                return java.util.Collections.emptyList();
+            }
+        };
 
     @Override
     public void onEnable() {
         if (getServer().getPluginManager().getPlugin("TeamsAPI") != null) {
-            TeamsAPI.registerSubcommand(this, statsSubcommand);
+            TeamsAPI.registerSubcommand(this, fSubcommand);
         }
     }
 
     @Override
     public void onDisable() {
-        TeamsAPI.unregisterSubcommand(statsSubcommand);
+        TeamsAPI.unregisterSubcommand(fSubcommand);
+    }
+
+    private boolean dispatch(final Player player, final String[] args) {
+        player.sendMessage("Factions " + args[1] + ": ...");
+        return true;
     }
 }
 ```

--- a/docs/provider-subcommands.md
+++ b/docs/provider-subcommands.md
@@ -16,12 +16,16 @@ description: "How to dispatch TeamsSubcommand registrations inside your team plu
 
 The custom subcommand system lets any third-party plugin extend your team plugin's
 command tree without you knowing about it at compile time. Your team plugin adds a
-dispatch loop inside its own `CommandExecutor` that checks `TeamsAPI.getSubcommands()`
+dispatch call inside its own `CommandExecutor` that checks `TeamsAPI.getSubcommands()`
 after handling its own built-in subcommands. When a match is found the registered
 `TeamsSubcommand` is called directly — in your command, under your permission system.
 
 This is the same Vault-style decoupling that makes `TeamsService` work: your plugin
 dispatches, other plugins register. Neither needs to know about the other.
+
+See [Registering Subcommands](consumer-subcommands) for the consumer side — how
+other plugins implement and register a `TeamsSubcommand` that your command will
+dispatch.
 
 ## 1. Declare the soft-dependency
 
@@ -36,14 +40,14 @@ loop is a no-op when `getSubcommands()` returns an empty collection, but you sti
 need to guard the `TeamsAPI` class reference itself (see
 [section 4](#4-guard-when-teamsapi-is-absent)).
 
-## 2. Add the dispatch loop to your `CommandExecutor`
+## 2. Add the dispatch call to your `CommandExecutor`
 
-After handling your plugin's own subcommands, fall through to
-`TeamsAPI.getSubcommands()`:
+After handling your plugin's own subcommands, call
+`TeamsAPI.dispatchSubcommand(sender, args)`. It returns `true` if a registered
+subcommand matched (handled or denied), so you only need one line:
 
 ```java
 import com.skyblockexp.teamsapi.api.TeamsAPI;
-import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -71,18 +75,8 @@ public class FactionsCommandExecutor implements CommandExecutor {
         }
 
         // Fall through to any registered TeamsSubcommand
-        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
-            if (sub.getName().equalsIgnoreCase(args[0])) {
-                final String perm = sub.getPermission();
-                if (perm != null && !sender.hasPermission(perm)) {
-                    sender.sendMessage("You do not have permission to use this command.");
-                    return true;
-                }
-                if (!sub.execute(sender, args)) {
-                    sender.sendMessage("Usage: " + sub.getUsage());
-                }
-                return true;
-            }
+        if (TeamsAPI.dispatchSubcommand(sender, args)) {
+            return true;
         }
 
         sender.sendMessage("Unknown subcommand. Use /" + label + " help.");
@@ -91,16 +85,17 @@ public class FactionsCommandExecutor implements CommandExecutor {
 }
 ```
 
-`args` is passed to `execute()` unchanged. The registered subcommand receives
-`args[0]` as its own name and its arguments starting at `args[1]`.
+`dispatchSubcommand` checks permissions, calls `execute()`, and sends the usage hint
+if `execute()` returns `false` — all in one call.
 
 ## 3. Add tab-complete dispatch
 
-Wire the same lookup into your `TabCompleter`:
+Merge your own subcommand names with those from
+`TeamsAPI.tabCompleteSubcommands(sender, args)`, which handles prefix filtering
+and permission gating automatically:
 
 ```java
 import com.skyblockexp.teamsapi.api.TeamsAPI;
-import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -116,30 +111,15 @@ public class FactionsTabCompleter implements TabCompleter {
     public List<String> onTabComplete(final CommandSender sender, final Command command,
             final String label, final String[] args) {
         if (args.length == 1) {
-            // Merge your own subcommand names with registered TeamsSubcommand names
+            // Merge your own names with registered TeamsSubcommand names
             final List<String> suggestions = new ArrayList<>(List.of("create", "disband"));
-            for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
-                final String perm = sub.getPermission();
-                if (perm == null || sender.hasPermission(perm)) {
-                    suggestions.add(sub.getName());
-                }
-            }
+            suggestions.addAll(TeamsAPI.tabCompleteSubcommands(sender, args));
             final String prefix = args[0].toLowerCase();
             suggestions.removeIf(s -> !s.toLowerCase().startsWith(prefix));
             return suggestions;
         }
         if (args.length > 1) {
-            // Delegate to the matched subcommand's tab-complete
-            for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
-                if (sub.getName().equalsIgnoreCase(args[0])) {
-                    final String perm = sub.getPermission();
-                    if (perm != null && !sender.hasPermission(perm)) {
-                        return Collections.emptyList();
-                    }
-                    final List<String> completions = sub.tabComplete(sender, args);
-                    return completions != null ? completions : Collections.emptyList();
-                }
-            }
+            return TeamsAPI.tabCompleteSubcommands(sender, args);
         }
         return Collections.emptyList();
     }

--- a/docs/provider-teams.md
+++ b/docs/provider-teams.md
@@ -174,4 +174,5 @@ exist before registration is attempted.
 
 - [Invite Provider](../provider-invites): adding optional invitation support
 - [Warp Provider](../provider-warps): adding optional warp support
+- [Custom Subcommands](../provider-subcommands): injecting subcommands into `/teamsapi`
 - [API Reference](../api): full interface and model documentation

--- a/docs/provider-warps.md
+++ b/docs/provider-warps.md
@@ -144,4 +144,5 @@ softdepend:
 
 - [Team Provider](../provider-teams): implementing the core `TeamsService`
 - [Invite Provider](../provider-invites): adding optional invitation support
+- [Custom Subcommands](../provider-subcommands): injecting subcommands into `/teamsapi`
 - [API Reference](../api): full interface and model documentation

--- a/docs/server-guide.md
+++ b/docs/server-guide.md
@@ -185,14 +185,15 @@ Yes. TeamsAPI provides the `/teamsapi` command for diagnostic and status checks.
 | `/teamsapi status` | `teamsapi.status` | everyone | Shows the active provider, team count, and which optional services are registered. |
 | `/teamsapi info` | `teamsapi.admin` | op | Detailed internal diagnostic: all five service types, registered subcommands, plugin version. |
 | `/teamsapi power status` | `teamsapi.power` | op | Shows the sender's current and maximum power. |
-| `/teamsapi power buy <amount>` | `teamsapi.power.buy` | op | Purchases power units (requires Vault and `power-shop.enabled: true` in config). |
+| `/teamsapi power buy <amount>` | `teamsapi.power.buy` | disabled | Disabled by default. Enable with `power-shop.enabled: true` in `config.yml`. Requires Vault. |
 
 Provider plugins may also register additional subcommands that appear in this list
 and can be run as `/teamsapi <name>`.
 
 **Where is the config file?**
 
-There is no config file. TeamsAPI requires no configuration.
+TeamsAPI generates a `plugins/TeamsAPI/config.yml` on first run. It controls the
+power shop and passive power regen features, both of which are disabled by default.
 
 ## Velocity setup
 

--- a/docs/server-guide.md
+++ b/docs/server-guide.md
@@ -177,8 +177,18 @@ their team-related features.
 
 **Does TeamsAPI add any commands or permissions?**
 
-No. TeamsAPI has no player-facing commands, no permissions, and no configuration
-file.
+Yes. TeamsAPI provides the `/teamsapi` command for diagnostic and status checks.
+
+| Subcommand | Permission | Default | Description |
+|------------|-----------|---------|-------------|
+| `/teamsapi` or `/teamsapi version` | `teamsapi.use` | everyone | Prints the installed API version. |
+| `/teamsapi status` | `teamsapi.status` | everyone | Shows the active provider, team count, and which optional services are registered. |
+| `/teamsapi info` | `teamsapi.admin` | op | Detailed internal diagnostic: all five service types, registered subcommands, plugin version. |
+| `/teamsapi power status` | `teamsapi.power` | op | Shows the sender's current and maximum power. |
+| `/teamsapi power buy <amount>` | `teamsapi.power.buy` | op | Purchases power units (requires Vault and `power-shop.enabled: true` in config). |
+
+Provider plugins may also register additional subcommands that appear in this list
+and can be run as `/teamsapi <name>`.
 
 **Where is the config file?**
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -29,7 +29,7 @@ consumer plugin keeps working without a recompile.
 - **Optional warp service**: providers can expose `TeamsWarpService` for named team warps.
 - **Optional claim service**: providers can expose `TeamsClaimService` for chunk-claim management.
 - **Optional power service**: providers can expose `TeamsPowerService` for player and team power values.
-- **Custom subcommands**: providers can inject additional `/teamsapi <name>` subcommands via `TeamsAPI.registerSubcommand()`, complete with per-subcommand permission nodes and help-text.
+- **Custom subcommands**: any plugin registers a `TeamsSubcommand` via `TeamsAPI.registerSubcommand()`; team plugins call `TeamsAPI.getSubcommands()` in their own command handler to dispatch them, extending the command tree without coupling.
 - **Cancellable events**: twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 - **Lightweight**: a single shaded JAR with no runtime dependencies beyond the Bukkit API.
 - **JitPack-ready**: depend on just the API module at compile time; no transitive dependencies leak into your plugin.
@@ -235,8 +235,11 @@ Consumers check availability with `TeamsAPI.isPowerAvailable()` before calling `
 
 ### Custom subcommands
 
-Providers can inject additional subcommands into `/teamsapi` without shipping a
-separate Bukkit command. Implement `TeamsSubcommand` and register it in `onEnable`:
+Any plugin can register a `TeamsSubcommand` via `TeamsAPI.registerSubcommand()`. Team
+plugins call `TeamsAPI.getSubcommands()` in their own command executor to dispatch them,
+extending the command tree without any direct coupling between plugins.
+
+Register in `onEnable`:
 
 ```java
 TeamsAPI.registerSubcommand(this, new MySubcommand());
@@ -251,13 +254,12 @@ TeamsAPI.unregisterSubcommand(mySubcommand);
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `getName()` | `String` | Matched case-insensitively against `args[0]` of `/teamsapi` |
-| `getDescription()` | `String` | Shown in `/teamsapi help` |
+| `getName()` | `String` | Matched case-insensitively against `args[0]` |
+| `getDescription()` | `String` | Optional description for help output |
 | `getPermission()` | `String` | Permission required, or `null` for no check |
-| `execute(sender, args)` | `boolean` | Called when the subcommand is dispatched |
-
-All registered subcommands appear in `/teamsapi help` for senders who have the
-required permission.
+| `execute(sender, args)` | `boolean` | Called when the subcommand is dispatched; return `false` to show usage |
+| `getUsage()` | `String` | Usage hint sent when `execute` returns `false` |
+| `tabComplete(sender, args)` | `List<String>` | Tab-completion suggestions; default: empty list |
 
 ### Commands & permissions
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -29,6 +29,7 @@ consumer plugin keeps working without a recompile.
 - **Optional warp service**: providers can expose `TeamsWarpService` for named team warps.
 - **Optional claim service**: providers can expose `TeamsClaimService` for chunk-claim management.
 - **Optional power service**: providers can expose `TeamsPowerService` for player and team power values.
+- **Custom subcommands**: providers can inject additional `/teamsapi <name>` subcommands via `TeamsAPI.registerSubcommand()`, complete with per-subcommand permission nodes and help-text.
 - **Cancellable events**: twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 - **Lightweight**: a single shaded JAR with no runtime dependencies beyond the Bukkit API.
 - **JitPack-ready**: depend on just the API module at compile time; no transitive dependencies leak into your plugin.
@@ -70,7 +71,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -82,7 +83,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.4.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 ```
 
@@ -231,6 +232,43 @@ TeamsAPI.registerPowerProvider(this, powerService);
 | `getTeamMaxPower(teamId)` | `double` | Maximum combined power the team can hold |
 
 Consumers check availability with `TeamsAPI.isPowerAvailable()` before calling `TeamsAPI.getPowerService()`.
+
+### Custom subcommands
+
+Providers can inject additional subcommands into `/teamsapi` without shipping a
+separate Bukkit command. Implement `TeamsSubcommand` and register it in `onEnable`:
+
+```java
+TeamsAPI.registerSubcommand(this, new MySubcommand());
+```
+
+Unregister in `onDisable` (Bukkit's ServicesManager also handles this automatically
+on plugin unload):
+
+```java
+TeamsAPI.unregisterSubcommand(mySubcommand);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getName()` | `String` | Matched case-insensitively against `args[0]` of `/teamsapi` |
+| `getDescription()` | `String` | Shown in `/teamsapi help` |
+| `getPermission()` | `String` | Permission required, or `null` for no check |
+| `execute(sender, args)` | `boolean` | Called when the subcommand is dispatched |
+
+All registered subcommands appear in `/teamsapi help` for senders who have the
+required permission.
+
+### Commands & permissions
+
+| Subcommand | Permission | Default | Description |
+|------------|-----------|---------|-------------|
+| `/teamsapi` / `/teamsapi help` | `teamsapi.use` | everyone | Lists commands the sender can use |
+| `/teamsapi version` | `teamsapi.use` | everyone | Prints plugin and API version |
+| `/teamsapi status` | `teamsapi.status` | everyone | Active provider, team count, registered services |
+| `/teamsapi info` | `teamsapi.admin` | op | Full internal diagnostic |
+| `/teamsapi power status` | `teamsapi.power` | op | Sender's current and max power |
+| `/teamsapi power buy <n>` | `teamsapi.power.buy` | op | Purchase power via Vault economy |
 
 ### Events
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -71,7 +71,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.5.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -83,7 +83,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
 }
 ```
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -270,7 +270,7 @@ TeamsAPI.unregisterSubcommand(mySubcommand);
 | `/teamsapi status` | `teamsapi.status` | everyone | Active provider, team count, registered services |
 | `/teamsapi info` | `teamsapi.admin` | op | Full internal diagnostic |
 | `/teamsapi power status` | `teamsapi.power` | op | Sender's current and max power |
-| `/teamsapi power buy <n>` | `teamsapi.power.buy` | op | Purchase power via Vault economy |
+| `/teamsapi power buy <n>` | `teamsapi.power.buy` | disabled | Disabled by default; enable with `power-shop.enabled: true` in `config.yml`. Requires Vault. |
 
 ### Events
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -30,7 +30,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 [*][B]Optional warp service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsWarpService[/COLOR] for named team warps.
 [*][B]Optional claim service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsClaimService[/COLOR] for chunk-claim management.
 [*][B]Optional power service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsPowerService[/COLOR] for player and team power values.
-[*][B]Custom subcommands[/B] -- providers can inject additional [COLOR=#6cb4ff]/teamsapi <name>[/COLOR] subcommands via [COLOR=#6cb4ff]TeamsAPI.registerSubcommand()[/COLOR], each with its own permission node and help text.
+[*][B]Custom subcommands[/B] -- any plugin registers a [COLOR=#6cb4ff]TeamsSubcommand[/COLOR] via [COLOR=#6cb4ff]TeamsAPI.registerSubcommand()[/COLOR]; team plugins call [COLOR=#6cb4ff]TeamsAPI.getSubcommands()[/COLOR] in their own command handler to dispatch them without coupling.
 [*][B]Cancellable events[/B] -- twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 [*][B]Lightweight[/B] -- a single shaded JAR with no runtime dependencies beyond the Bukkit API.
 [*][B]JitPack-ready[/B] -- depend on just the API module at compile time via Maven or Gradle.
@@ -214,7 +214,7 @@ public void onDisable() {
 
 [SIZE=4][B]Custom subcommands[/B][/SIZE]
 
-[COLOR=#aaaaaa]Providers can inject subcommands into [COLOR=#6cb4ff]/teamsapi[/COLOR] without shipping a separate Bukkit command.[/COLOR]
+[COLOR=#aaaaaa]Any plugin registers a [COLOR=#6cb4ff]TeamsSubcommand[/COLOR] and team plugins call [COLOR=#6cb4ff]TeamsAPI.getSubcommands()[/COLOR] in their own command executor to dispatch them. This extends the team plugin's command tree without any coupling between plugins.[/COLOR]
 
 [CODE=java]
 // onEnable
@@ -225,10 +225,12 @@ TeamsAPI.unregisterSubcommand(mySubcommand);
 [/CODE]
 
 [LIST]
-[*][COLOR=#6cb4ff]getName()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Matched case-insensitively against the first argument of [COLOR=#6cb4ff]/teamsapi[/COLOR]
-[*][COLOR=#6cb4ff]getDescription()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Shown in [COLOR=#6cb4ff]/teamsapi help[/COLOR]
+[*][COLOR=#6cb4ff]getName()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Matched case-insensitively against the first argument
+[*][COLOR=#6cb4ff]getDescription()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Optional description for help output
 [*][COLOR=#6cb4ff]getPermission()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Permission required, or [COLOR=#f08080]null[/COLOR] for no check
-[*][COLOR=#6cb4ff]execute(sender, args)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Called when the subcommand is dispatched
+[*][COLOR=#6cb4ff]execute(sender, args)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Called when the subcommand is dispatched; return [COLOR=#f08080]false[/COLOR] to show usage
+[*][COLOR=#6cb4ff]getUsage()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Usage hint sent when [COLOR=#6cb4ff]execute[/COLOR] returns [COLOR=#f08080]false[/COLOR]
+[*][COLOR=#6cb4ff]tabComplete(sender, args)[/COLOR] -> [COLOR=#ffd700]List<String>[/COLOR] -- Tab-completion suggestions; default: empty list
 [/LIST]
 
 [SIZE=4][B]Commands & permissions[/B][/SIZE]

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -75,7 +75,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.5.0</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -87,7 +87,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
 }
 [/CODE]
 [/SPOILER]

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -241,7 +241,7 @@ TeamsAPI.unregisterSubcommand(mySubcommand);
 [*][COLOR=#6cb4ff]/teamsapi status[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.status[/COLOR] (default: everyone)[/COLOR] -- Active provider, team count, registered services
 [*][COLOR=#6cb4ff]/teamsapi info[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.admin[/COLOR] (default: op)[/COLOR] -- Full internal diagnostic
 [*][COLOR=#6cb4ff]/teamsapi power status[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.power[/COLOR] (default: op)[/COLOR] -- Sender's current and max power
-[*][COLOR=#6cb4ff]/teamsapi power buy <n>[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.power.buy[/COLOR] (default: op)[/COLOR] -- Purchase power via Vault economy
+[*][COLOR=#6cb4ff]/teamsapi power buy <n>[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.power.buy[/COLOR] (default: disabled)[/COLOR] -- Disabled by default; enable with [COLOR=#ffd700]power-shop.enabled: true[/COLOR] in config.yml. Requires Vault.
 [/LIST]
 
 [SIZE=4][B]Events[/B][/SIZE]

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -30,6 +30,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 [*][B]Optional warp service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsWarpService[/COLOR] for named team warps.
 [*][B]Optional claim service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsClaimService[/COLOR] for chunk-claim management.
 [*][B]Optional power service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsPowerService[/COLOR] for player and team power values.
+[*][B]Custom subcommands[/B] -- providers can inject additional [COLOR=#6cb4ff]/teamsapi <name>[/COLOR] subcommands via [COLOR=#6cb4ff]TeamsAPI.registerSubcommand()[/COLOR], each with its own permission node and help text.
 [*][B]Cancellable events[/B] -- twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 [*][B]Lightweight[/B] -- a single shaded JAR with no runtime dependencies beyond the Bukkit API.
 [*][B]JitPack-ready[/B] -- depend on just the API module at compile time via Maven or Gradle.
@@ -74,7 +75,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -86,7 +87,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.4.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 [/CODE]
 [/SPOILER]
@@ -209,6 +210,36 @@ public void onDisable() {
 [*][COLOR=#6cb4ff]setPlayerPower(playerUUID, power)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Sets the player's power
 [*][COLOR=#6cb4ff]getTeamPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Combined power of all team members
 [*][COLOR=#6cb4ff]getTeamMaxPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Maximum combined power the team can hold
+[/LIST]
+
+[SIZE=4][B]Custom subcommands[/B][/SIZE]
+
+[COLOR=#aaaaaa]Providers can inject subcommands into [COLOR=#6cb4ff]/teamsapi[/COLOR] without shipping a separate Bukkit command.[/COLOR]
+
+[CODE=java]
+// onEnable
+TeamsAPI.registerSubcommand(this, new MySubcommand());
+
+// onDisable
+TeamsAPI.unregisterSubcommand(mySubcommand);
+[/CODE]
+
+[LIST]
+[*][COLOR=#6cb4ff]getName()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Matched case-insensitively against the first argument of [COLOR=#6cb4ff]/teamsapi[/COLOR]
+[*][COLOR=#6cb4ff]getDescription()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Shown in [COLOR=#6cb4ff]/teamsapi help[/COLOR]
+[*][COLOR=#6cb4ff]getPermission()[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- Permission required, or [COLOR=#f08080]null[/COLOR] for no check
+[*][COLOR=#6cb4ff]execute(sender, args)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Called when the subcommand is dispatched
+[/LIST]
+
+[SIZE=4][B]Commands & permissions[/B][/SIZE]
+
+[LIST]
+[*][COLOR=#6cb4ff]/teamsapi[/COLOR] / [COLOR=#6cb4ff]/teamsapi help[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.use[/COLOR] (default: everyone)[/COLOR] -- Lists commands the sender can use
+[*][COLOR=#6cb4ff]/teamsapi version[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.use[/COLOR] (default: everyone)[/COLOR] -- Prints plugin and API version
+[*][COLOR=#6cb4ff]/teamsapi status[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.status[/COLOR] (default: everyone)[/COLOR] -- Active provider, team count, registered services
+[*][COLOR=#6cb4ff]/teamsapi info[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.admin[/COLOR] (default: op)[/COLOR] -- Full internal diagnostic
+[*][COLOR=#6cb4ff]/teamsapi power status[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.power[/COLOR] (default: op)[/COLOR] -- Sender's current and max power
+[*][COLOR=#6cb4ff]/teamsapi power buy <n>[/COLOR] -- [COLOR=#aaaaaa]requires [COLOR=#ffd700]teamsapi.power.buy[/COLOR] (default: op)[/COLOR] -- Purchase power via Vault economy
 [/LIST]
 
 [SIZE=4][B]Events[/B][/SIZE]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
+++ b/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
@@ -8,7 +8,10 @@ import com.skyblockexp.teamsapi.model.TeamMember;
 import com.skyblockexp.teamsapi.model.TeamRole;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -259,6 +262,108 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
 
         sendHelp(sender);
         return true;
+    }
+
+    /**
+     * Handles tab-completion for the {@code /teamsapi} command.
+     *
+     * <p>Returns the matching built-in subcommand names when completing the
+     * first argument. Delegates to {@link TeamsSubcommand#tabComplete} for
+     * registered custom subcommands when completing further arguments.</p>
+     *
+     * @param sender  the command sender requesting completions
+     * @param command the dispatched command
+     * @param label   the alias used
+     * @param args    the arguments typed so far
+     * @return a list of completion strings; never {@code null}
+     */
+    List<String> handleTabComplete(final CommandSender sender, final Command command,
+            final String label, final String[] args) {
+        if (!command.getName().equalsIgnoreCase("teamsapi")) {
+            return Collections.emptyList();
+        }
+        if (!sender.hasPermission("teamsapi.use")) {
+            return Collections.emptyList();
+        }
+        if (args.length == 1) {
+            return filterByPrefix(buildTopLevelCompletions(sender), args[0]);
+        }
+        if (args[0].equalsIgnoreCase("power") && args.length == 2) {
+            return filterByPrefix(buildPowerCompletions(sender), args[1]);
+        }
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    return Collections.emptyList();
+                }
+                return sub.tabComplete(sender, args);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Builds the list of top-level subcommand names visible to the given sender.
+     *
+     * @param sender the command sender
+     * @return a mutable list of completion candidates
+     */
+    private static List<String> buildTopLevelCompletions(final CommandSender sender) {
+        final List<String> completions = new ArrayList<>();
+        completions.add("version");
+        completions.add("help");
+        if (sender.hasPermission("teamsapi.status")) {
+            completions.add("status");
+        }
+        if (sender.hasPermission("teamsapi.admin")) {
+            completions.add("info");
+        }
+        if (sender.hasPermission("teamsapi.power")) {
+            completions.add("power");
+        }
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            final String perm = sub.getPermission();
+            if (perm == null || sender.hasPermission(perm)) {
+                completions.add(sub.getName());
+            }
+        }
+        return completions;
+    }
+
+    /**
+     * Builds the list of {@code /teamsapi power} sub-argument completions visible
+     * to the given sender.
+     *
+     * @param sender the command sender
+     * @return a mutable list of completion candidates
+     */
+    private static List<String> buildPowerCompletions(final CommandSender sender) {
+        final List<String> completions = new ArrayList<>();
+        completions.add("status");
+        if (sender.hasPermission("teamsapi.power.buy")) {
+            completions.add("buy");
+        }
+        return completions;
+    }
+
+    /**
+     * Filters a list of completion candidates by a case-insensitive prefix.
+     *
+     * @param candidates the full candidate list
+     * @param prefix     the partial input to filter by
+     * @return a new list containing only candidates that start with the prefix
+     */
+    private static List<String> filterByPrefix(final List<String> candidates,
+            final String prefix) {
+        final String lower = prefix.toLowerCase();
+        final List<String> result = new ArrayList<>();
+        for (final String candidate : candidates) {
+            if (candidate.toLowerCase().startsWith(lower)) {
+                result.add(candidate);
+            }
+        }
+        return result;
     }
 
     /**

--- a/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
+++ b/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
@@ -205,6 +205,11 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
             return false;
         }
 
+        if (!sender.hasPermission("teamsapi.use")) {
+            sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+            return true;
+        }
+
         if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
             sendHelp(sender);
             return true;
@@ -218,11 +223,19 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
         }
 
         if (args[0].equalsIgnoreCase("status")) {
+            if (!sender.hasPermission("teamsapi.status")) {
+                sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+                return true;
+            }
             sendStatus(sender);
             return true;
         }
 
         if (args[0].equalsIgnoreCase("info")) {
+            if (!sender.hasPermission("teamsapi.admin")) {
+                sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+                return true;
+            }
             sendInfo(sender);
             return true;
         }
@@ -256,12 +269,23 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
     private static void sendHelp(final CommandSender sender) {
         sender.sendMessage("[TeamsAPI] Commands:");
         sender.sendMessage("  /teamsapi version          - Show version info");
-        sender.sendMessage("  /teamsapi status           - Show TeamsAPI status");
-        sender.sendMessage("  /teamsapi info             - Show detailed provider info (op)");
-        sender.sendMessage("  /teamsapi power status     - Show your current power");
-        sender.sendMessage("  /teamsapi power buy <n>    - Purchase power (requires Vault)");
+        if (sender.hasPermission("teamsapi.status")) {
+            sender.sendMessage("  /teamsapi status           - Show TeamsAPI status");
+        }
+        if (sender.hasPermission("teamsapi.admin")) {
+            sender.sendMessage("  /teamsapi info             - Show detailed provider info (op)");
+        }
+        if (sender.hasPermission("teamsapi.power")) {
+            sender.sendMessage("  /teamsapi power status     - Show your current power");
+        }
+        if (sender.hasPermission("teamsapi.power.buy")) {
+            sender.sendMessage("  /teamsapi power buy <n>    - Purchase power (requires Vault)");
+        }
         for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
-            sender.sendMessage("  /teamsapi " + sub.getName() + " - " + sub.getDescription());
+            final String perm = sub.getPermission();
+            if (perm == null || sender.hasPermission(perm)) {
+                sender.sendMessage("  /teamsapi " + sub.getName() + " - " + sub.getDescription());
+            }
         }
     }
 

--- a/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
+++ b/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
@@ -2,6 +2,7 @@ package com.skyblockexp.teamsapi;
 
 import com.skyblockexp.teamsapi.api.TeamsAPI;
 import com.skyblockexp.teamsapi.api.TeamsService;
+import com.skyblockexp.teamsapi.api.TeamsSubcommand;
 import com.skyblockexp.teamsapi.model.Team;
 import com.skyblockexp.teamsapi.model.TeamMember;
 import com.skyblockexp.teamsapi.model.TeamRole;
@@ -216,6 +217,11 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("status")) {
+            sendStatus(sender);
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("info")) {
             sendInfo(sender);
             return true;
@@ -224,6 +230,18 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
         if (args[0].equalsIgnoreCase("power")) {
             handlePowerCommand(sender, args);
             return true;
+        }
+
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+                    return true;
+                }
+                sub.execute(sender, args);
+                return true;
+            }
         }
 
         sendHelp(sender);
@@ -237,10 +255,14 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
      */
     private static void sendHelp(final CommandSender sender) {
         sender.sendMessage("[TeamsAPI] Commands:");
-        sender.sendMessage("  /teamsapi version        - Show version info");
-        sender.sendMessage("  /teamsapi info           - Show active provider info");
-        sender.sendMessage("  /teamsapi power status   - Show your current power");
-        sender.sendMessage("  /teamsapi power buy <n>  - Purchase power (requires Vault)");
+        sender.sendMessage("  /teamsapi version          - Show version info");
+        sender.sendMessage("  /teamsapi status           - Show TeamsAPI status");
+        sender.sendMessage("  /teamsapi info             - Show detailed provider info (op)");
+        sender.sendMessage("  /teamsapi power status     - Show your current power");
+        sender.sendMessage("  /teamsapi power buy <n>    - Purchase power (requires Vault)");
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            sender.sendMessage("  /teamsapi " + sub.getName() + " - " + sub.getDescription());
+        }
     }
 
     /**
@@ -325,20 +347,69 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
     }
 
     /**
+     * Sends a brief, player-friendly status summary to the given sender.
+     *
+     * <p>Shows the active provider, team count, and which optional services
+     * are currently registered. No admin permission is required.</p>
+     *
+     * @param sender the command sender to message
+     */
+    private static void sendStatus(final CommandSender sender) {
+        if (!TeamsAPI.isAvailable()) {
+            sender.sendMessage("[TeamsAPI] No team plugin is currently active.");
+            return;
+        }
+        final TeamsService service = TeamsAPI.getService();
+        sender.sendMessage("[TeamsAPI] Status: active");
+        sender.sendMessage("[TeamsAPI] Provider: " + service.getClass().getSimpleName());
+        sender.sendMessage("[TeamsAPI] Teams: " + service.getTeamCount());
+        final StringBuilder services = new StringBuilder("teams");
+        if (TeamsAPI.isInviteAvailable()) {
+            services.append(", invites");
+        }
+        if (TeamsAPI.isWarpAvailable()) {
+            services.append(", warps");
+        }
+        if (TeamsAPI.isClaimAvailable()) {
+            services.append(", claims");
+        }
+        if (TeamsAPI.isPowerAvailable()) {
+            services.append(", power");
+        }
+        sender.sendMessage("[TeamsAPI] Services: " + services);
+    }
+
+    /**
      * Sends provider information to the given sender.
      *
      * @param sender the command sender to message
      */
     private static void sendInfo(final CommandSender sender) {
-        if (!TeamsAPI.isAvailable()) {
-            sender.sendMessage("[TeamsAPI] No TeamsService provider is currently registered.");
-            return;
-        }
-
-        final TeamsService service = TeamsAPI.getService();
         sender.sendMessage("[TeamsAPI] API Version: " + TeamsAPI.API_VERSION);
-        sender.sendMessage("[TeamsAPI] Provider: " + service.getClass().getName());
-        sender.sendMessage("[TeamsAPI] Teams loaded: " + service.getTeamCount());
+        if (!TeamsAPI.isAvailable()) {
+            sender.sendMessage("[TeamsAPI] TeamsService:  none");
+        }
+        else {
+            final TeamsService service = TeamsAPI.getService();
+            sender.sendMessage("[TeamsAPI] TeamsService:  " + service.getClass().getName());
+            sender.sendMessage("[TeamsAPI] Teams loaded: " + service.getTeamCount());
+        }
+        final String inviteInfo = TeamsAPI.isInviteAvailable()
+            ? TeamsAPI.getInviteService().getClass().getName() : "none";
+        sender.sendMessage("[TeamsAPI] InviteService: " + inviteInfo);
+        final String warpInfo = TeamsAPI.isWarpAvailable()
+            ? TeamsAPI.getWarpService().getClass().getName() : "none";
+        sender.sendMessage("[TeamsAPI] WarpService:   " + warpInfo);
+        final String claimInfo = TeamsAPI.isClaimAvailable()
+            ? TeamsAPI.getClaimService().getClass().getName() : "none";
+        sender.sendMessage("[TeamsAPI] ClaimService:  " + claimInfo);
+        final String powerInfo = TeamsAPI.isPowerAvailable()
+            ? TeamsAPI.getPowerService().getClass().getName() : "none";
+        sender.sendMessage("[TeamsAPI] PowerService:  " + powerInfo);
+        final Collection<TeamsSubcommand> subs = TeamsAPI.getSubcommands();
+        if (!subs.isEmpty()) {
+            sender.sendMessage("[TeamsAPI] Subcommands: " + subs.size() + " registered");
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
+++ b/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/PluginBootstrap.java
@@ -255,7 +255,9 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
                     sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
                     return true;
                 }
-                sub.execute(sender, args);
+                if (!sub.execute(sender, args)) {
+                    sender.sendMessage("[TeamsAPI] Usage: " + sub.getUsage());
+                }
                 return true;
             }
         }
@@ -297,7 +299,8 @@ final class PluginBootstrap implements Listener, PluginMessageListener {
                 if (perm != null && !sender.hasPermission(perm)) {
                     return Collections.emptyList();
                 }
-                return sub.tabComplete(sender, args);
+                final List<String> completions = sub.tabComplete(sender, args);
+                return completions != null ? completions : Collections.emptyList();
             }
         }
         return Collections.emptyList();

--- a/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/TeamsApiPlugin.java
+++ b/teams-api-plugin/src/main/java/com/skyblockexp/teamsapi/TeamsApiPlugin.java
@@ -1,5 +1,7 @@
 package com.skyblockexp.teamsapi;
 
+import java.util.List;
+
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -50,6 +52,15 @@ public final class TeamsApiPlugin extends JavaPlugin {
     public boolean onCommand(final CommandSender sender, final Command command,
             final String label, final String[] args) {
         return bootstrap.handleCommand(sender, command, label, args);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> onTabComplete(final CommandSender sender,
+            final Command command, final String label, final String[] args) {
+        return bootstrap.handleTabComplete(sender, command, label, args);
     }
 
 }

--- a/teams-api-plugin/src/main/resources/plugin.yml
+++ b/teams-api-plugin/src/main/resources/plugin.yml
@@ -12,13 +12,19 @@ website: https://github.com/ez-plugins/teams-api
 commands:
   teamsapi:
     description: TeamsAPI admin command.
-    usage: /teamsapi [version|info|power [status|buy <amount>]]
-    permission: teamsapi.admin
+    usage: /teamsapi [version|status|info|power [status|buy <amount>]]
+    permission: teamsapi.use
 
 permissions:
   teamsapi.admin:
     description: Access to TeamsAPI admin commands.
     default: op
+  teamsapi.use:
+    description: Access to basic /teamsapi commands (version, status, help).
+    default: true
+  teamsapi.status:
+    description: Access to /teamsapi status — shows active provider and services.
+    default: true
   teamsapi.power:
     description: Access to /teamsapi power subcommands (status and buy).
     default: op

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
@@ -1,0 +1,101 @@
+package com.skyblockexp.teamsapi.api;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * Convenience base class for implementing {@link TeamsSubcommand}.
+ *
+ * <p>Stores name, description, and permission as constructor arguments so
+ * providers only need to implement {@link #execute}. Tab-completion returns an
+ * empty list by default; override {@link #tabComplete} to add suggestions.</p>
+ *
+ * <p><strong>Example:</strong></p>
+ * <pre>{@code
+ * public class StatsSubcommand extends AbstractTeamsSubcommand {
+ *
+ *     public StatsSubcommand() {
+ *         super("stats", "Show your team statistics.", "myplugin.stats");
+ *     }
+ *
+ *     @Override
+ *     public boolean execute(CommandSender sender, String[] args) {
+ *         sender.sendMessage("Stats: ...");
+ *         return true;
+ *     }
+ * }
+ * }</pre>
+ */
+public abstract class AbstractTeamsSubcommand implements TeamsSubcommand {
+
+    /** The subcommand name. */
+    private final String name;
+
+    /** The description shown in {@code /teamsapi help}. */
+    private final String description;
+
+    /** The required permission node, or {@code null} for open access. */
+    private final String permission;
+
+    /**
+     * Creates a new subcommand with no permission restriction.
+     *
+     * @param name        the subcommand name; matched case-insensitively
+     * @param description the short description shown in {@code /teamsapi help}
+     */
+    protected AbstractTeamsSubcommand(final String name, final String description) {
+        this(name, description, null);
+    }
+
+    /**
+     * Creates a new subcommand.
+     *
+     * @param name        the subcommand name; matched case-insensitively
+     * @param description the short description shown in {@code /teamsapi help}
+     * @param permission  the required Bukkit permission node, or {@code null}
+     *                    for open access (anyone with {@code teamsapi.use})
+     */
+    protected AbstractTeamsSubcommand(final String name, final String description,
+            final String permission) {
+        this.name = name;
+        this.description = description;
+        this.permission = permission;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getName() {
+        return name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getDescription() {
+        return description;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final String getPermission() {
+        return permission;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Returns an empty list by default. Override to provide completions.</p>
+     */
+    @Override
+    public List<String> tabComplete(final CommandSender sender, final String[] args) {
+        return Collections.emptyList();
+    }
+
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
@@ -10,7 +10,7 @@ import org.bukkit.command.CommandSender;
  * Convenience base class for implementing {@link TeamsSubcommand}.
  *
  * <p>Stores name, description, and permission as constructor arguments so
- * providers only need to implement {@link #execute}. Tab-completion returns an
+ * consumers only need to implement {@link #execute}. Tab-completion returns an
  * empty list by default; override {@link #tabComplete} to add suggestions.</p>
  *
  * <p><strong>Example:</strong></p>

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/AbstractTeamsSubcommand.java
@@ -2,6 +2,7 @@ package com.skyblockexp.teamsapi.api;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.command.CommandSender;
 
@@ -59,8 +60,8 @@ public abstract class AbstractTeamsSubcommand implements TeamsSubcommand {
      */
     protected AbstractTeamsSubcommand(final String name, final String description,
             final String permission) {
-        this.name = name;
-        this.description = description;
+        this.name = Objects.requireNonNull(name, "name must not be null");
+        this.description = Objects.requireNonNull(description, "description must not be null");
         this.permission = permission;
     }
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -1,5 +1,9 @@
 package com.skyblockexp.teamsapi.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -45,7 +49,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.5.0";
+    public static final String API_VERSION = "1.6.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }
@@ -528,4 +532,74 @@ public final class TeamsAPI {
 
         Bukkit.getServicesManager().unregister(TeamsPowerService.class, provider);
     }
+
+    // -------------------------------------------------------------------------
+    // Custom subcommand registration and dispatch
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns all {@link TeamsSubcommand} instances currently registered by providers.
+     *
+     * <p>The returned collection is a mutable snapshot ordered by Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} priority. Modifying the returned
+     * collection has no effect on the registry.</p>
+     *
+     * @return a collection of registered subcommands; never {@code null}, may be empty
+     */
+    public static Collection<TeamsSubcommand> getSubcommands() {
+        try {
+            final Collection<RegisteredServiceProvider<TeamsSubcommand>> registrations =
+                Bukkit.getServicesManager().getRegistrations(TeamsSubcommand.class);
+            final Collection<TeamsSubcommand> result = new ArrayList<>(registrations.size());
+            for (final RegisteredServiceProvider<TeamsSubcommand> rsp : registrations) {
+                result.add(rsp.getProvider());
+            }
+            return result;
+        }
+        catch (Throwable ignored) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Registers a {@link TeamsSubcommand} with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>Once registered, the subcommand is available as
+     * {@code /teamsapi <name> [args...]} and will appear in
+     * {@code /teamsapi help}.</p>
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin     the plugin registering the subcommand; must not be {@code null}
+     * @param subcommand the subcommand implementation; must not be {@code null}
+     */
+    public static void registerSubcommand(final Plugin plugin,
+            final TeamsSubcommand subcommand) {
+        if (plugin == null || subcommand == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsSubcommand.class, subcommand, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Unregisters a {@link TeamsSubcommand} from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param subcommand the subcommand to unregister; may be {@code null}
+     */
+    public static void unregisterSubcommand(final TeamsSubcommand subcommand) {
+        if (subcommand == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsSubcommand.class, subcommand);
+    }
+
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -3,8 +3,11 @@ package com.skyblockexp.teamsapi.api;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.ServicePriority;
@@ -565,9 +568,9 @@ public final class TeamsAPI {
      * Registers a {@link TeamsSubcommand} with Bukkit's
      * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
      *
-     * <p>Once registered, the subcommand is available as
-     * {@code /teamsapi <name> [args...]} and will appear in
-     * {@code /teamsapi help}.</p>
+     * <p>Once registered, the subcommand is available to any provider plugin
+     * that calls {@link #dispatchSubcommand} or iterates {@link #getSubcommands}
+     * inside its own command handler.</p>
      *
      * <p>This method silently ignores {@code null} arguments.</p>
      *
@@ -600,6 +603,100 @@ public final class TeamsAPI {
         }
 
         Bukkit.getServicesManager().unregister(TeamsSubcommand.class, subcommand);
+    }
+
+    /**
+     * Dispatches the first matching registered {@link TeamsSubcommand} for the
+     * given arguments.
+     *
+     * <p>Provider plugins call this at the end of their own
+     * {@code CommandExecutor.onCommand()} after handling their built-in
+     * subcommands. If a registered subcommand whose
+     * {@link TeamsSubcommand#getName()} matches {@code args[0]}
+     * (case-insensitive) is found, this method:
+     * <ol>
+     *   <li>Checks the subcommand's permission (if non-null); sends a denial
+     *       message and returns {@code true} if the sender lacks it.</li>
+     *   <li>Calls {@link TeamsSubcommand#execute(CommandSender, String[])}.</li>
+     *   <li>Sends the usage hint if {@code execute} returns {@code false}.</li>
+     * </ol>
+     * </p>
+     *
+     * @param sender the command sender; must not be {@code null}
+     * @param args   the full argument array from {@code onCommand};
+     *               {@code args[0]} is matched against registered names
+     * @return {@code true} if a matching subcommand was found and dispatched;
+     *         {@code false} if no match was found
+     */
+    public static boolean dispatchSubcommand(final CommandSender sender,
+            final String[] args) {
+        if (sender == null || args == null || args.length == 0) {
+            return false;
+        }
+
+        for (final TeamsSubcommand sub : getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    sender.sendMessage("You do not have permission to use this command.");
+                    return true;
+                }
+                if (!sub.execute(sender, args)) {
+                    sender.sendMessage("Usage: " + sub.getUsage());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns tab-completion suggestions from registered {@link TeamsSubcommand}
+     * instances.
+     *
+     * <p>Provider plugins call this from their {@code TabCompleter.onTabComplete()}
+     * to delegate completion to registered subcommands. The return value can be
+     * merged with the provider's own suggestions or returned directly.</p>
+     *
+     * <p>When {@code args.length == 1}, returns the names of all subcommands the
+     * sender is permitted to use, filtered to those starting with {@code args[0]}.
+     * When {@code args.length > 1}, delegates to the matching subcommand's
+     * {@link TeamsSubcommand#tabComplete}.</p>
+     *
+     * @param sender the command sender; must not be {@code null}
+     * @param args   the argument array from {@code onTabComplete}
+     * @return a list of suggestions; never {@code null}, may be empty
+     */
+    public static List<String> tabCompleteSubcommands(final CommandSender sender,
+            final String[] args) {
+        if (sender == null || args == null || args.length == 0) {
+            return Collections.emptyList();
+        }
+
+        if (args.length == 1) {
+            final String prefix = args[0].toLowerCase(Locale.ROOT);
+            final List<String> result = new ArrayList<>();
+            for (final TeamsSubcommand sub : getSubcommands()) {
+                final String perm = sub.getPermission();
+                if ((perm == null || sender.hasPermission(perm))
+                        && sub.getName().toLowerCase(Locale.ROOT).startsWith(prefix)) {
+                    result.add(sub.getName());
+                }
+            }
+            return result;
+        }
+
+        for (final TeamsSubcommand sub : getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    return Collections.emptyList();
+                }
+                final List<String> completions = sub.tabComplete(sender, args);
+                return completions != null ? completions : Collections.emptyList();
+            }
+        }
+        return Collections.emptyList();
     }
 
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
@@ -6,23 +6,25 @@ import java.util.List;
 import org.bukkit.command.CommandSender;
 
 /**
- * Contract for a custom subcommand that can be injected into the
- * {@code /teamsapi} command tree by a provider plugin.
+ * Contract for a custom subcommand that consumer plugins can register with TeamsAPI
+ * so that team plugins (providers) can dispatch it inside their own command handler.
  *
  * <p>Register an implementation via {@link TeamsAPI#registerSubcommand} in your
  * plugin's {@code onEnable} and unregister it in {@code onDisable}. Once
- * registered, the command is dispatched as
- * {@code /teamsapi <name> [args...]} and listed in {@code /teamsapi help}.</p>
+ * registered, any provider that calls {@link TeamsAPI#dispatchSubcommand} (or
+ * iterates {@link TeamsAPI#getSubcommands}) will include this subcommand in its
+ * own command tree — for example as {@code /factions stats} or
+ * {@code /clans stats}.</p>
  *
- * <p><strong>Provider registration example:</strong></p>
+ * <p><strong>Consumer registration example:</strong></p>
  * <pre>{@code
  * // onEnable
  * TeamsAPI.registerSubcommand(this, new TeamsSubcommand() {
- *     public String getName()        { return "factions"; }
- *     public String getDescription() { return "Show faction info."; }
- *     public String getPermission()  { return "myplugin.factions"; }
+ *     public String getName()        { return "stats"; }
+ *     public String getDescription() { return "Show team statistics."; }
+ *     public String getPermission()  { return "myplugin.stats"; }
  *     public boolean execute(CommandSender sender, String[] args) {
- *         sender.sendMessage("Your faction: ...");
+ *         sender.sendMessage("Stats: ...");
  *         return true;
  *     }
  * });
@@ -79,21 +81,21 @@ public interface TeamsSubcommand {
      * Returns a usage string shown to the sender when {@link #execute} returns
      * {@code false}.
      *
-     * <p>The default implementation returns {@code "/teamsapi <name>"}. Override
-     * to include expected arguments, e.g. {@code "/teamsapi stats <player>"}.</p>
+     * <p>The default implementation returns the subcommand name. Override to
+     * include expected arguments, e.g. {@code "stats [player]"}.</p>
      *
      * @return the usage string; never {@code null}
      */
     default String getUsage() {
-        return "/teamsapi " + getName();
+        return getName();
     }
 
     /**
      * Returns tab-completion suggestions for this subcommand.
      *
-     * <p>Called by TeamsAPI when a player presses Tab after typing
-     * {@code /teamsapi <name> ...}. {@code args[0]} is always this subcommand's
-     * name; additional partial input follows from {@code args[1]} onward.</p>
+     * <p>Called by the provider's tab-completer when the first argument matches
+     * this subcommand's name. {@code args[0]} is always this subcommand's name;
+     * additional partial input follows from {@code args[1]} onward.</p>
      *
      * <p>The default implementation returns an empty list (no completions).
      * Override to provide context-aware suggestions.</p>

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
@@ -1,0 +1,75 @@
+package com.skyblockexp.teamsapi.api;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * Contract for a custom subcommand that can be injected into the
+ * {@code /teamsapi} command tree by a provider plugin.
+ *
+ * <p>Register an implementation via {@link TeamsAPI#registerSubcommand} in your
+ * plugin's {@code onEnable} and unregister it in {@code onDisable}. Once
+ * registered, the command is dispatched as
+ * {@code /teamsapi <name> [args...]} and listed in {@code /teamsapi help}.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // onEnable
+ * TeamsAPI.registerSubcommand(this, new TeamsSubcommand() {
+ *     public String getName()        { return "factions"; }
+ *     public String getDescription() { return "Show faction info."; }
+ *     public String getPermission()  { return "myplugin.factions"; }
+ *     public boolean execute(CommandSender sender, String[] args) {
+ *         sender.sendMessage("Your faction: ...");
+ *         return true;
+ *     }
+ * });
+ *
+ * // onDisable
+ * TeamsAPI.unregisterSubcommand(mySubcommand);
+ * }</pre>
+ */
+public interface TeamsSubcommand {
+
+    /**
+     * Returns the name of this subcommand (case-insensitive match against
+     * the first argument after {@code /teamsapi}).
+     *
+     * @return the subcommand name; never {@code null} or empty
+     */
+    String getName();
+
+    /**
+     * Returns a short human-readable description shown in {@code /teamsapi help}.
+     *
+     * @return the description; never {@code null}
+     */
+    String getDescription();
+
+    /**
+     * Returns the Bukkit permission node required to execute this subcommand,
+     * or {@code null} if no permission check is performed.
+     *
+     * <p>When non-null, TeamsAPI checks the sender's permission before calling
+     * {@link #execute}. If the check fails, a denial message is sent and
+     * {@link #execute} is not called.</p>
+     *
+     * @return the permission node, or {@code null} for open access
+     */
+    String getPermission();
+
+    /**
+     * Executes this subcommand.
+     *
+     * <p>{@code args[0]} contains the subcommand name (i.e. the value of
+     * {@link #getName()}). Additional arguments follow from {@code args[1]}
+     * onward.</p>
+     *
+     * @param sender the command sender; never {@code null}
+     * @param args   the arguments passed to {@code /teamsapi <args...>};
+     *               {@code args[0]} is always this subcommand's name
+     * @return {@code true} if the command was handled; {@code false} to let
+     *         TeamsAPI print the default usage hint
+     */
+    boolean execute(CommandSender sender, String[] args);
+
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
@@ -1,5 +1,8 @@
 package com.skyblockexp.teamsapi.api;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.bukkit.command.CommandSender;
 
 /**
@@ -71,5 +74,24 @@ public interface TeamsSubcommand {
      *         TeamsAPI print the default usage hint
      */
     boolean execute(CommandSender sender, String[] args);
+
+    /**
+     * Returns tab-completion suggestions for this subcommand.
+     *
+     * <p>Called by TeamsAPI when a player presses Tab after typing
+     * {@code /teamsapi <name> ...}. {@code args[0]} is always this subcommand's
+     * name; additional partial input follows from {@code args[1]} onward.</p>
+     *
+     * <p>The default implementation returns an empty list (no completions).
+     * Override to provide context-aware suggestions.</p>
+     *
+     * @param sender the command sender requesting completions; never {@code null}
+     * @param args   the arguments typed so far; {@code args[0]} is this
+     *               subcommand's name
+     * @return a list of completion strings; never {@code null}
+     */
+    default List<String> tabComplete(CommandSender sender, String[] args) {
+        return Collections.emptyList();
+    }
 
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsSubcommand.java
@@ -76,6 +76,19 @@ public interface TeamsSubcommand {
     boolean execute(CommandSender sender, String[] args);
 
     /**
+     * Returns a usage string shown to the sender when {@link #execute} returns
+     * {@code false}.
+     *
+     * <p>The default implementation returns {@code "/teamsapi <name>"}. Override
+     * to include expected arguments, e.g. {@code "/teamsapi stats <player>"}.</p>
+     *
+     * @return the usage string; never {@code null}
+     */
+    default String getUsage() {
+        return "/teamsapi " + getName();
+    }
+
+    /**
      * Returns tab-completion suggestions for this subcommand.
      *
      * <p>Called by TeamsAPI when a player presses Tab after typing

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandDispatchTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandDispatchTest.java
@@ -1,0 +1,351 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for {@link TeamsAPI#dispatchSubcommand} and
+ * {@link TeamsAPI#tabCompleteSubcommands}.
+ */
+class TeamsAPISubcommandDispatchTest {
+
+    /** Owning plugin used for service registration. */
+    private PluginMock plugin;
+
+    /**
+     * Sets up MockBukkit and loads a test plugin before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // -------------------------------------------------------------------------
+    // dispatchSubcommand — basic dispatch
+    // -------------------------------------------------------------------------
+
+    /**
+     * dispatchSubcommand_matchingName_returnsTrue verifies that when a subcommand
+     * with a matching name is registered, dispatchSubcommand returns true and calls
+     * execute().
+     */
+    @Test
+    void dispatchSubcommand_matchingName_returnsTrue() {
+        final boolean[] executed = {false};
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        final boolean result = TeamsAPI.dispatchSubcommand(sender, new String[]{"stats"});
+
+        assertTrue(result);
+        assertTrue(executed[0]);
+    }
+
+    /**
+     * dispatchSubcommand_caseInsensitiveMatch_returnsTrue verifies that name matching
+     * is case-insensitive.
+     */
+    @Test
+    void dispatchSubcommand_caseInsensitiveMatch_returnsTrue() {
+        final boolean[] executed = {false};
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "STATS"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        final boolean result = TeamsAPI.dispatchSubcommand(sender, new String[]{"stats"});
+
+        assertTrue(result);
+        assertTrue(executed[0]);
+    }
+
+    /**
+     * dispatchSubcommand_noMatch_returnsFalse verifies that when no registered
+     * subcommand matches args[0], dispatchSubcommand returns false.
+     */
+    @Test
+    void dispatchSubcommand_noMatch_returnsFalse() {
+        final CommandSender sender = mock(CommandSender.class);
+
+        final boolean result = TeamsAPI.dispatchSubcommand(sender, new String[]{"unknown"});
+
+        assertFalse(result);
+        verify(sender, never()).sendMessage(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    /**
+     * dispatchSubcommand_permissionDenied_returnsTrueWithoutCallingExecute verifies
+     * that when the sender lacks the required permission, execute() is not called and
+     * true is returned.
+     */
+    @Test
+    void dispatchSubcommand_permissionDenied_returnsTrueWithoutCallingExecute() {
+        final boolean[] executed = {false};
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return "myplugin.stats"; }
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myplugin.stats")).thenReturn(false);
+
+        final boolean result = TeamsAPI.dispatchSubcommand(sender, new String[]{"stats"});
+
+        assertTrue(result);
+        assertFalse(executed[0]);
+        verify(sender).sendMessage(contains("permission"));
+    }
+
+    /**
+     * dispatchSubcommand_executeReturnsFalse_sendsUsageHint verifies that when
+     * execute() returns false, the usage hint is sent to the sender.
+     */
+    @Test
+    void dispatchSubcommand_executeReturnsFalse_sendsUsageHint() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public String getUsage() { return "stats <player>"; }
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return false;
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        TeamsAPI.dispatchSubcommand(sender, new String[]{"stats"});
+
+        verify(sender).sendMessage(contains("stats <player>"));
+    }
+
+    /**
+     * dispatchSubcommand_nullSender_returnsFalse verifies that null sender is handled
+     * gracefully and returns false.
+     */
+    @Test
+    void dispatchSubcommand_nullSender_returnsFalse() {
+        assertFalse(TeamsAPI.dispatchSubcommand(null, new String[]{"stats"}));
+    }
+
+    /**
+     * dispatchSubcommand_emptyArgs_returnsFalse verifies that an empty args array is
+     * handled gracefully and returns false.
+     */
+    @Test
+    void dispatchSubcommand_emptyArgs_returnsFalse() {
+        final CommandSender sender = mock(CommandSender.class);
+        assertFalse(TeamsAPI.dispatchSubcommand(sender, new String[]{}));
+    }
+
+    /**
+     * dispatchSubcommand_nullArgs_returnsFalse verifies that a null args array is
+     * handled gracefully and returns false.
+     */
+    @Test
+    void dispatchSubcommand_nullArgs_returnsFalse() {
+        final CommandSender sender = mock(CommandSender.class);
+        assertFalse(TeamsAPI.dispatchSubcommand(sender, null));
+    }
+
+    // -------------------------------------------------------------------------
+    // tabCompleteSubcommands — length 1
+    // -------------------------------------------------------------------------
+
+    /**
+     * tabCompleteSubcommands_lengthOne_returnsPermittedNames verifies that when
+     * args.length == 1, the names of all permitted subcommands are returned.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthOne_returnsPermittedNames() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(sender, new String[]{"s"});
+
+        assertNotNull(result);
+        assertTrue(result.contains("stats"));
+    }
+
+    /**
+     * tabCompleteSubcommands_lengthOne_filtersByPrefix verifies that names not
+     * starting with the typed prefix are excluded.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthOne_filtersByPrefix() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+        });
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "top"; }
+            public String getDescription() { return "Top."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(sender, new String[]{"st"});
+
+        assertTrue(result.contains("stats"));
+        assertFalse(result.contains("top"));
+    }
+
+    /**
+     * tabCompleteSubcommands_lengthOne_excludesPermissionDenied verifies that
+     * subcommands the sender lacks permission for are excluded from completions.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthOne_excludesPermissionDenied() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "admin"; }
+            public String getDescription() { return "Admin."; }
+            public String getPermission() { return "myplugin.admin"; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myplugin.admin")).thenReturn(false);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(sender, new String[]{""});
+
+        assertFalse(result.contains("admin"));
+    }
+
+    // -------------------------------------------------------------------------
+    // tabCompleteSubcommands — length > 1
+    // -------------------------------------------------------------------------
+
+    /**
+     * tabCompleteSubcommands_lengthTwo_delegatesToSubcommand verifies that when
+     * args.length > 1, the call is delegated to the matching subcommand's tabComplete.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthTwo_delegatesToSubcommand() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "stats"; }
+            public String getDescription() { return "Stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("player1", "player2");
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(
+                sender, new String[]{"stats", "p"});
+
+        assertEquals(List.of("player1", "player2"), result);
+    }
+
+    /**
+     * tabCompleteSubcommands_lengthTwo_noMatch_returnsEmpty verifies that when
+     * args.length > 1 and no subcommand matches args[0], an empty list is returned.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthTwo_noMatch_returnsEmpty() {
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(
+                sender, new String[]{"unknown", "x"});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * tabCompleteSubcommands_nullArgs_returnsEmpty verifies that a null args array
+     * is handled gracefully.
+     */
+    @Test
+    void tabCompleteSubcommands_nullArgs_returnsEmpty() {
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(sender, null);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * tabCompleteSubcommands_lengthTwo_permissionDenied_returnsEmpty verifies that
+     * when the sender lacks the subcommand's permission, no completions are returned.
+     */
+    @Test
+    void tabCompleteSubcommands_lengthTwo_permissionDenied_returnsEmpty() {
+        TeamsAPI.registerSubcommand(plugin, new TeamsSubcommand() {
+            public String getName() { return "admin"; }
+            public String getDescription() { return "Admin."; }
+            public String getPermission() { return "myplugin.admin"; }
+            public boolean execute(final CommandSender s, final String[] a) { return true; }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("secret");
+            }
+        });
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myplugin.admin")).thenReturn(false);
+
+        final List<String> result = TeamsAPI.tabCompleteSubcommands(
+                sender, new String[]{"admin", "s"});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
@@ -1,0 +1,166 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+
+import org.bukkit.command.CommandSender;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for {@link TeamsAPI} subcommand registration methods:
+ * {@link TeamsAPI#registerSubcommand}, {@link TeamsAPI#unregisterSubcommand},
+ * and {@link TeamsAPI#getSubcommands}.
+ *
+ * <p>Tests verify that subcommands are stored and retrieved via Bukkit's
+ * ServicesManager and that null-safety contracts hold.</p>
+ */
+class TeamsAPISubcommandTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * getSubcommands_returnsEmpty_whenNoneRegistered verifies that
+     * {@link TeamsAPI#getSubcommands()} returns an empty collection when no
+     * subcommand has been registered.
+     */
+    @Test
+    void getSubcommands_returnsEmpty_whenNoneRegistered() {
+        final Collection<TeamsSubcommand> subs = TeamsAPI.getSubcommands();
+
+        assertTrue(subs.isEmpty());
+    }
+
+    /**
+     * registerSubcommand_makesSubcommandRetrievable verifies that after calling
+     * {@link TeamsAPI#registerSubcommand}, the subcommand is returned by
+     * {@link TeamsAPI#getSubcommands()}.
+     */
+    @Test
+    void registerSubcommand_makesSubcommandRetrievable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = mock(TeamsSubcommand.class);
+        when(sub.getName()).thenReturn("test");
+
+        TeamsAPI.registerSubcommand(plugin, sub);
+
+        assertTrue(TeamsAPI.getSubcommands().contains(sub));
+    }
+
+    /**
+     * registerSubcommand_multipleSubcommands_allRetrievable verifies that two distinct
+     * subcommands registered by the same plugin are both returned by
+     * {@link TeamsAPI#getSubcommands()}.
+     */
+    @Test
+    void registerSubcommand_multipleSubcommands_allRetrievable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand subA = mock(TeamsSubcommand.class);
+        final TeamsSubcommand subB = mock(TeamsSubcommand.class);
+        when(subA.getName()).thenReturn("alpha");
+        when(subB.getName()).thenReturn("beta");
+
+        TeamsAPI.registerSubcommand(plugin, subA);
+        TeamsAPI.registerSubcommand(plugin, subB);
+
+        final Collection<TeamsSubcommand> subs = TeamsAPI.getSubcommands();
+        assertTrue(subs.contains(subA));
+        assertTrue(subs.contains(subB));
+        assertEquals(2, subs.size());
+    }
+
+    /**
+     * unregisterSubcommand_removesSubcommand verifies that after calling
+     * {@link TeamsAPI#unregisterSubcommand}, the subcommand is no longer returned by
+     * {@link TeamsAPI#getSubcommands()}.
+     */
+    @Test
+    void unregisterSubcommand_removesSubcommand() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = mock(TeamsSubcommand.class);
+        when(sub.getName()).thenReturn("test");
+
+        TeamsAPI.registerSubcommand(plugin, sub);
+        TeamsAPI.unregisterSubcommand(sub);
+
+        assertFalse(TeamsAPI.getSubcommands().contains(sub));
+    }
+
+    /**
+     * registerSubcommand_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin leaves the subcommand list empty.
+     */
+    @Test
+    void registerSubcommand_withNullPlugin_doesNotRegister() {
+        final TeamsSubcommand sub = mock(TeamsSubcommand.class);
+
+        TeamsAPI.registerSubcommand(null, sub);
+
+        assertTrue(TeamsAPI.getSubcommands().isEmpty());
+    }
+
+    /**
+     * registerSubcommand_withNullSubcommand_doesNotRegister verifies that passing a
+     * {@code null} subcommand leaves the subcommand list empty.
+     */
+    @Test
+    void registerSubcommand_withNullSubcommand_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerSubcommand(plugin, null);
+
+        assertTrue(TeamsAPI.getSubcommands().isEmpty());
+    }
+
+    /**
+     * unregisterSubcommand_withNull_doesNotThrow verifies that calling
+     * {@link TeamsAPI#unregisterSubcommand} with {@code null} does not throw.
+     */
+    @Test
+    void unregisterSubcommand_withNull_doesNotThrow() {
+        TeamsAPI.unregisterSubcommand(null);
+        // no exception — test passes
+    }
+
+    /**
+     * teamsSubcommand_getPermission_canReturnNull verifies that a {@link TeamsSubcommand}
+     * implementation may return {@code null} from {@link TeamsSubcommand#getPermission()}.
+     */
+    @Test
+    void teamsSubcommand_getPermission_canReturnNull() {
+        final TeamsSubcommand sub = new TeamsSubcommand() {
+            public String getName() { return "open"; }
+            public String getDescription() { return "Open command."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        assertTrue(sub.getPermission() == null || sub.getPermission().isEmpty()
+            || !sub.getPermission().isEmpty());
+    }
+
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -162,8 +163,58 @@ class TeamsAPISubcommandTest {
             public boolean execute(final CommandSender sender, final String[] args) { return true; }
         };
 
-        assertTrue(sub.getPermission() == null || sub.getPermission().isEmpty()
-            || !sub.getPermission().isEmpty());
+        assertNull(sub.getPermission());
+    }
+
+    /**
+     * teamsSubcommand_getUsage_defaultIncludesName verifies that the default
+     * {@link TeamsSubcommand#getUsage()} implementation includes the subcommand name.
+     */
+    @Test
+    void teamsSubcommand_getUsage_defaultIncludesName() {
+        final TeamsSubcommand sub = new TeamsSubcommand() {
+            public String getName() { return "mystats"; }
+            public String getDescription() { return "Show stats."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        final String usage = sub.getUsage();
+
+        assertNotNull(usage);
+        assertTrue(usage.contains("mystats"));
+    }
+
+    /**
+     * abstractTeamsSubcommand_constructor_throwsOnNullName verifies that passing
+     * {@code null} as the name to {@link AbstractTeamsSubcommand} throws
+     * {@link NullPointerException}.
+     */
+    @Test
+    void abstractTeamsSubcommand_constructor_throwsOnNullName() {
+        assertThrows(NullPointerException.class, () ->
+            new AbstractTeamsSubcommand(null, "description") {
+                public boolean execute(final CommandSender sender, final String[] args) {
+                    return true;
+                }
+            }
+        );
+    }
+
+    /**
+     * abstractTeamsSubcommand_constructor_throwsOnNullDescription verifies that passing
+     * {@code null} as the description to {@link AbstractTeamsSubcommand} throws
+     * {@link NullPointerException}.
+     */
+    @Test
+    void abstractTeamsSubcommand_constructor_throwsOnNullDescription() {
+        assertThrows(NullPointerException.class, () ->
+            new AbstractTeamsSubcommand("name", null) {
+                public boolean execute(final CommandSender sender, final String[] args) {
+                    return true;
+                }
+            }
+        );
     }
 
     /**

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPISubcommandTest.java
@@ -2,11 +2,14 @@ package com.skyblockexp.teamsapi.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
+import java.util.List;
 
 import org.bukkit.command.CommandSender;
 
@@ -161,6 +164,125 @@ class TeamsAPISubcommandTest {
 
         assertTrue(sub.getPermission() == null || sub.getPermission().isEmpty()
             || !sub.getPermission().isEmpty());
+    }
+
+    /**
+     * teamsSubcommand_tabComplete_defaultReturnsEmptyList verifies that the default
+     * {@link TeamsSubcommand#tabComplete} implementation returns an empty, non-null list.
+     */
+    @Test
+    void teamsSubcommand_tabComplete_defaultReturnsEmptyList() {
+        final TeamsSubcommand sub = new TeamsSubcommand() {
+            public String getName() { return "tab"; }
+            public String getDescription() { return "Tab test."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = sub.tabComplete(sender, new String[]{"tab"});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * abstractTeamsSubcommand_getName_returnsConstructorValue verifies that
+     * {@link AbstractTeamsSubcommand#getName()} returns the value passed to the constructor.
+     */
+    @Test
+    void abstractTeamsSubcommand_getName_returnsConstructorValue() {
+        final AbstractTeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.") {
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        assertEquals("mystats", sub.getName());
+    }
+
+    /**
+     * abstractTeamsSubcommand_getDescription_returnsConstructorValue verifies that
+     * {@link AbstractTeamsSubcommand#getDescription()} returns the value passed to the
+     * constructor.
+     */
+    @Test
+    void abstractTeamsSubcommand_getDescription_returnsConstructorValue() {
+        final AbstractTeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.") {
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        assertEquals("Show stats.", sub.getDescription());
+    }
+
+    /**
+     * abstractTeamsSubcommand_getPermission_returnsNullWhenNotProvided verifies that
+     * the two-argument constructor sets permission to {@code null}.
+     */
+    @Test
+    void abstractTeamsSubcommand_getPermission_returnsNullWhenNotProvided() {
+        final AbstractTeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.") {
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        assertNull(sub.getPermission());
+    }
+
+    /**
+     * abstractTeamsSubcommand_getPermission_returnsPermissionWhenProvided verifies that
+     * the three-argument constructor exposes the permission node via
+     * {@link AbstractTeamsSubcommand#getPermission()}.
+     */
+    @Test
+    void abstractTeamsSubcommand_getPermission_returnsPermissionWhenProvided() {
+        final AbstractTeamsSubcommand sub =
+            new AbstractTeamsSubcommand("mystats", "Show stats.", "myplugin.stats") {
+                public boolean execute(final CommandSender sender, final String[] args) {
+                    return true;
+                }
+            };
+
+        assertEquals("myplugin.stats", sub.getPermission());
+    }
+
+    /**
+     * abstractTeamsSubcommand_tabComplete_defaultReturnsEmptyList verifies that
+     * {@link AbstractTeamsSubcommand#tabComplete} returns an empty, non-null list when
+     * not overridden.
+     */
+    @Test
+    void abstractTeamsSubcommand_tabComplete_defaultReturnsEmptyList() {
+        final AbstractTeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.") {
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = sub.tabComplete(sender, new String[]{"mystats"});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * abstractTeamsSubcommand_tabComplete_customOverrideIsUsed verifies that a subclass
+     * can override {@link AbstractTeamsSubcommand#tabComplete} and the overridden value
+     * is returned.
+     */
+    @Test
+    void abstractTeamsSubcommand_tabComplete_customOverrideIsUsed() {
+        final AbstractTeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.") {
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("player1", "player2");
+            }
+        };
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = sub.tabComplete(sender, new String[]{"mystats"});
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains("player1"));
+        assertTrue(result.contains("player2"));
     }
 
 }

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsSubcommandFeatureTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsSubcommandFeatureTest.java
@@ -1,0 +1,331 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Feature tests for the custom subcommand system.
+ *
+ * <p>These tests verify the observable behaviour of the subcommand feature from a provider
+ * plugin's perspective: dispatch, permission gating, usage hints, and tab-completion.
+ * Dispatch logic mirrors what {@code PluginBootstrap.handleCommand} and
+ * {@code PluginBootstrap.handleTabComplete} perform at runtime.</p>
+ */
+class TeamsSubcommandFeatureTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * Simulates the PluginBootstrap command dispatch loop for a given argument array.
+     *
+     * @param sender the command sender
+     * @param args   the argument array; {@code args[0]} is the subcommand name
+     * @return {@code true} if a registered subcommand matched and was dispatched
+     */
+    private static boolean simulateDispatch(final CommandSender sender, final String[] args) {
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+                    return true;
+                }
+                if (!sub.execute(sender, args)) {
+                    sender.sendMessage("[TeamsAPI] Usage: " + sub.getUsage());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Simulates the PluginBootstrap tab-complete dispatch loop for a given argument array.
+     *
+     * @param sender the command sender
+     * @param args   the argument array; {@code args[0]} is the subcommand name
+     * @return completions from the matching subcommand; never {@code null}
+     */
+    private static List<String> simulateTabComplete(final CommandSender sender,
+            final String[] args) {
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    return Collections.emptyList();
+                }
+                final List<String> completions = sub.tabComplete(sender, args);
+                return completions != null ? completions : Collections.emptyList();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * dispatch_findsSubcommandByName_andExecutesIt verifies that the dispatch loop
+     * finds a registered subcommand by its name and calls
+     * {@link TeamsSubcommand#execute}.
+     */
+    @Test
+    void dispatch_findsSubcommandByName_andExecutesIt() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final boolean dispatched = simulateDispatch(sender, new String[]{"f"});
+
+        assertTrue(dispatched);
+        assertTrue(executed[0]);
+    }
+
+    /**
+     * dispatch_isCaseInsensitive_matchingSubcommand verifies that the dispatch loop
+     * matches subcommand names case-insensitively (e.g. "STATS" matches "stats").
+     */
+    @Test
+    void dispatch_isCaseInsensitive_matchingSubcommand() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("stats", "Show stats.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        simulateDispatch(sender, new String[]{"STATS"});
+
+        assertTrue(executed[0]);
+    }
+
+    /**
+     * dispatch_returnsNoMatch_whenNameDoesNotMatch verifies that the dispatch loop
+     * returns {@code false} and does not call {@link TeamsSubcommand#execute} when no
+     * registered subcommand matches the given name.
+     */
+    @Test
+    void dispatch_returnsNoMatch_whenNameDoesNotMatch() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final boolean dispatched = simulateDispatch(sender, new String[]{"g"});
+
+        assertFalse(dispatched);
+        assertFalse(executed[0]);
+    }
+
+    /**
+     * dispatch_blocksExecution_whenPermissionCheckFails verifies that when a subcommand
+     * has a non-null permission node and the sender lacks it,
+     * {@link TeamsSubcommand#execute} is not called.
+     */
+    @Test
+    void dispatch_blocksExecution_whenPermissionCheckFails() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.",
+                "myfactions.use") {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myfactions.use")).thenReturn(false);
+
+        simulateDispatch(sender, new String[]{"f"});
+
+        assertFalse(executed[0]);
+    }
+
+    /**
+     * dispatch_allowsExecution_whenPermissionIsNull verifies that when a subcommand's
+     * permission is {@code null}, {@link TeamsSubcommand#execute} is called for any sender.
+     */
+    @Test
+    void dispatch_allowsExecution_whenPermissionIsNull() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("open", "Open command.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        simulateDispatch(sender, new String[]{"open"});
+
+        assertTrue(executed[0]);
+    }
+
+    /**
+     * dispatch_sendsUsageHint_whenExecuteReturnsFalse verifies that when
+     * {@link TeamsSubcommand#execute} returns {@code false}, the dispatch loop sends a
+     * message containing the subcommand's usage string to the sender.
+     */
+    @Test
+    void dispatch_sendsUsageHint_whenExecuteReturnsFalse() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public String getUsage() {
+                return "/teamsapi f <subcommand>";
+            }
+
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return false;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        simulateDispatch(sender, new String[]{"f"});
+
+        verify(sender).sendMessage(contains("/teamsapi f <subcommand>"));
+    }
+
+    /**
+     * tabComplete_delegatesToSubcommand_whenNameMatches verifies that the tab-complete
+     * dispatch delegates to the registered subcommand's {@link TeamsSubcommand#tabComplete}
+     * and returns its result.
+     */
+    @Test
+    void tabComplete_delegatesToSubcommand_whenNameMatches() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("stats", "Show stats.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("player1", "player2");
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = simulateTabComplete(sender, new String[]{"stats", ""});
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains("player1"));
+        assertTrue(result.contains("player2"));
+    }
+
+    /**
+     * tabComplete_returnsEmpty_whenPermissionCheckFails verifies that the tab-complete
+     * dispatch returns an empty list when the sender lacks the required permission.
+     */
+    @Test
+    void tabComplete_returnsEmpty_whenPermissionCheckFails() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.",
+                "myfactions.tab") {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("create", "delete");
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myfactions.tab")).thenReturn(false);
+
+        final List<String> result = simulateTabComplete(sender, new String[]{"f", ""});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * tabComplete_handlesNullReturnFromSubcommand_gracefully verifies that when a
+     * subcommand's {@link TeamsSubcommand#tabComplete} returns {@code null}, the dispatch
+     * loop returns an empty list rather than propagating a {@link NullPointerException}.
+     */
+    @Test
+    void tabComplete_handlesNullReturnFromSubcommand_gracefully() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new TeamsSubcommand() {
+            public String getName() { return "nullsub"; }
+            public String getDescription() { return "Returns null from tabComplete."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return null;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = simulateTabComplete(sender, new String[]{"nullsub", ""});
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsSubcommandIntegrationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsSubcommandIntegrationTest.java
@@ -1,0 +1,391 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Integration tests for the custom subcommand system, covering multi-provider
+ * registration, coexistence, and full plugin lifecycle scenarios.
+ *
+ * <p>Each test simulates the realistic scenario where one or more provider plugins
+ * register subcommands during {@code onEnable} and unregister them during
+ * {@code onDisable}, then verifies that the TeamsAPI registry and dispatch
+ * behave correctly across the complete lifecycle.</p>
+ */
+class TeamsSubcommandIntegrationTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * Simulates the PluginBootstrap command dispatch loop.
+     *
+     * @param sender the command sender
+     * @param args   the argument array; {@code args[0]} is the subcommand name
+     * @return {@code true} if a registered subcommand matched and was dispatched
+     */
+    private static boolean simulateDispatch(final CommandSender sender, final String[] args) {
+        for (final TeamsSubcommand sub : TeamsAPI.getSubcommands()) {
+            if (sub.getName().equalsIgnoreCase(args[0])) {
+                final String perm = sub.getPermission();
+                if (perm != null && !sender.hasPermission(perm)) {
+                    sender.sendMessage("[TeamsAPI] You do not have permission to use this command.");
+                    return true;
+                }
+                if (!sub.execute(sender, args)) {
+                    sender.sendMessage("[TeamsAPI] Usage: " + sub.getUsage());
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * twoProviderPlugins_registerSubcommands_bothAvailableInGetSubcommands verifies that
+     * when two different plugins each register one subcommand, both are returned by
+     * {@link TeamsAPI#getSubcommands()}.
+     */
+    @Test
+    void twoProviderPlugins_registerSubcommands_bothAvailableInGetSubcommands() {
+        final PluginMock pluginA = PluginMock.builder().withPluginName("PluginA").build();
+        final PluginMock pluginB = PluginMock.builder().withPluginName("PluginB").build();
+        final TeamsSubcommand subF = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+        final TeamsSubcommand subG = new AbstractTeamsSubcommand("g", "Guilds.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+
+        TeamsAPI.registerSubcommand(pluginA, subF);
+        TeamsAPI.registerSubcommand(pluginB, subG);
+
+        final Collection<TeamsSubcommand> subs = TeamsAPI.getSubcommands();
+        assertTrue(subs.contains(subF));
+        assertTrue(subs.contains(subG));
+        assertEquals(2, subs.size());
+    }
+
+    /**
+     * oneProviderUnregisters_otherSubcommandRemainsAvailable verifies that when one
+     * provider unregisters its subcommand, the other provider's subcommand is still
+     * returned by {@link TeamsAPI#getSubcommands()}.
+     */
+    @Test
+    void oneProviderUnregisters_otherSubcommandRemainsAvailable() {
+        final PluginMock pluginA = PluginMock.builder().withPluginName("PluginA").build();
+        final PluginMock pluginB = PluginMock.builder().withPluginName("PluginB").build();
+        final TeamsSubcommand subF = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+        final TeamsSubcommand subG = new AbstractTeamsSubcommand("g", "Guilds.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) { return true; }
+        };
+        TeamsAPI.registerSubcommand(pluginA, subF);
+        TeamsAPI.registerSubcommand(pluginB, subG);
+
+        TeamsAPI.unregisterSubcommand(subF);
+
+        final Collection<TeamsSubcommand> subs = TeamsAPI.getSubcommands();
+        assertFalse(subs.contains(subF));
+        assertTrue(subs.contains(subG));
+        assertEquals(1, subs.size());
+    }
+
+    /**
+     * fullLifecycle_registerOnEnable_dispatch_unregisterOnDisable verifies the complete
+     * provider plugin lifecycle: register during {@code onEnable}, dispatch executes
+     * correctly, and unregister during {@code onDisable} leaves the registry empty.
+     */
+    @Test
+    void fullLifecycle_registerOnEnable_dispatch_unregisterOnDisable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("FactionPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+
+        // simulate onEnable
+        TeamsAPI.registerSubcommand(plugin, sub);
+
+        // simulate dispatch
+        final CommandSender sender = mock(CommandSender.class);
+        simulateDispatch(sender, new String[]{"f"});
+        assertTrue(executed[0]);
+
+        // simulate onDisable
+        TeamsAPI.unregisterSubcommand(sub);
+        assertTrue(TeamsAPI.getSubcommands().isEmpty());
+    }
+
+    /**
+     * rawInterfaceSubcommand_andAbstractSubcommand_coexistCorrectly verifies that a
+     * raw {@link TeamsSubcommand} implementation and a concrete
+     * {@link AbstractTeamsSubcommand} implementation can be registered simultaneously and
+     * both dispatched correctly.
+     */
+    @Test
+    void rawInterfaceSubcommand_andAbstractSubcommand_coexistCorrectly() {
+        final PluginMock pluginA = PluginMock.builder().withPluginName("PluginA").build();
+        final PluginMock pluginB = PluginMock.builder().withPluginName("PluginB").build();
+        final boolean[] rawExecuted = {false};
+        final boolean[] abstractExecuted = {false};
+        final TeamsSubcommand rawSub = new TeamsSubcommand() {
+            public String getName() { return "raw"; }
+            public String getDescription() { return "Raw subcommand."; }
+            public String getPermission() { return null; }
+            public boolean execute(final CommandSender sender, final String[] args) {
+                rawExecuted[0] = true;
+                return true;
+            }
+        };
+        final TeamsSubcommand abstractSub = new AbstractTeamsSubcommand(
+                "abstract", "Abstract subcommand.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                abstractExecuted[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(pluginA, rawSub);
+        TeamsAPI.registerSubcommand(pluginB, abstractSub);
+
+        final CommandSender sender = mock(CommandSender.class);
+        simulateDispatch(sender, new String[]{"raw"});
+        simulateDispatch(sender, new String[]{"abstract"});
+
+        assertTrue(rawExecuted[0]);
+        assertTrue(abstractExecuted[0]);
+    }
+
+    /**
+     * subcommandPermissionGate_preventsExecution_inDispatchLoop verifies that when a
+     * subcommand requires a permission the sender does not have, the dispatch loop does
+     * not call {@link TeamsSubcommand#execute}.
+     */
+    @Test
+    void subcommandPermissionGate_preventsExecution_inDispatchLoop() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final boolean[] executed = {false};
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("secure", "Secured command.",
+                "myplugin.secure") {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                executed[0] = true;
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("myplugin.secure")).thenReturn(false);
+
+        simulateDispatch(sender, new String[]{"secure"});
+
+        assertFalse(executed[0]);
+    }
+
+    /**
+     * abstractSubcommand_withCustomTabComplete_returnsOverriddenCompletions verifies
+     * that a concrete {@link AbstractTeamsSubcommand} with an overridden
+     * {@link TeamsSubcommand#tabComplete} returns its custom completion list when
+     * retrieved through the API.
+     */
+    @Test
+    void abstractSubcommand_withCustomTabComplete_returnsOverriddenCompletions() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("stats", "Show stats.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+
+            @Override
+            public List<String> tabComplete(final CommandSender sender, final String[] args) {
+                return List.of("top", "me", "team");
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final TeamsSubcommand found = TeamsAPI.getSubcommands().iterator().next();
+        final List<String> completions = found.tabComplete(sender, new String[]{"stats", ""});
+
+        assertEquals(3, completions.size());
+        assertTrue(completions.contains("top"));
+        assertTrue(completions.contains("me"));
+        assertTrue(completions.contains("team"));
+    }
+
+    /**
+     * subcommandUsageOverride_isReflectedInDispatch verifies that when a subcommand
+     * overrides {@link TeamsSubcommand#getUsage()}, the overridden value is what the
+     * dispatch loop would send as a usage hint.
+     */
+    @Test
+    void subcommandUsageOverride_isReflectedInDispatch() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public String getUsage() {
+                return "/teamsapi f [create|delete|list]";
+            }
+
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+
+        final TeamsSubcommand found = TeamsAPI.getSubcommands().iterator().next();
+
+        assertEquals("/teamsapi f [create|delete|list]", found.getUsage());
+    }
+
+    /**
+     * threeProviders_unregisterMiddle_otherTwoRemain verifies that when three provider
+     * plugins register subcommands and one is unregistered, the other two remain in
+     * {@link TeamsAPI#getSubcommands()} independently.
+     */
+    @Test
+    void threeProviders_unregisterMiddle_otherTwoRemain() {
+        final PluginMock pluginA = PluginMock.builder().withPluginName("PluginA").build();
+        final PluginMock pluginB = PluginMock.builder().withPluginName("PluginB").build();
+        final PluginMock pluginC = PluginMock.builder().withPluginName("PluginC").build();
+        final TeamsSubcommand subA = new AbstractTeamsSubcommand("a", "A command.", null) {
+            @Override
+            public boolean execute(final CommandSender s, final String[] args) { return true; }
+        };
+        final TeamsSubcommand subB = new AbstractTeamsSubcommand("b", "B command.", null) {
+            @Override
+            public boolean execute(final CommandSender s, final String[] args) { return true; }
+        };
+        final TeamsSubcommand subC = new AbstractTeamsSubcommand("c", "C command.", null) {
+            @Override
+            public boolean execute(final CommandSender s, final String[] args) { return true; }
+        };
+        TeamsAPI.registerSubcommand(pluginA, subA);
+        TeamsAPI.registerSubcommand(pluginB, subB);
+        TeamsAPI.registerSubcommand(pluginC, subC);
+
+        TeamsAPI.unregisterSubcommand(subB);
+
+        final Collection<TeamsSubcommand> remaining = TeamsAPI.getSubcommands();
+        assertTrue(remaining.contains(subA));
+        assertFalse(remaining.contains(subB));
+        assertTrue(remaining.contains(subC));
+        assertEquals(2, remaining.size());
+    }
+
+    /**
+     * subcommand_defaultGetUsage_containsSubcommandName verifies that the interface
+     * default {@link TeamsSubcommand#getUsage()} implementation includes the subcommand
+     * name, as seen through the API registry.
+     */
+    @Test
+    void subcommand_defaultGetUsage_containsSubcommandName() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("mystats", "Show stats.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+
+        final TeamsSubcommand found = TeamsAPI.getSubcommands().iterator().next();
+
+        assertTrue(found.getUsage().contains("mystats"));
+    }
+
+    /**
+     * subcommand_emptyTabComplete_byDefault_returnsNotNull verifies that a
+     * {@link AbstractTeamsSubcommand} that does not override {@code tabComplete} returns
+     * a non-null empty list through the API registry.
+     */
+    @Test
+    void subcommand_emptyTabComplete_byDefault_returnsNotNull() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("info", "Info command.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final TeamsSubcommand found = TeamsAPI.getSubcommands().iterator().next();
+        final List<String> completions = found.tabComplete(sender, new String[]{"info", ""});
+
+        assertTrue(completions != null && completions.isEmpty());
+    }
+
+    /**
+     * dispatchLoop_tabComplete_returnsEmptyList_whenNoSubcommandMatches verifies that
+     * when no registered subcommand matches the given name, the simulated tab-complete
+     * dispatch returns an empty list.
+     */
+    @Test
+    void dispatchLoop_tabComplete_returnsEmptyList_whenNoSubcommandMatches() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsSubcommand sub = new AbstractTeamsSubcommand("f", "Factions.", null) {
+            @Override
+            public boolean execute(final CommandSender sender, final String[] args) {
+                return true;
+            }
+        };
+        TeamsAPI.registerSubcommand(plugin, sub);
+        final CommandSender sender = mock(CommandSender.class);
+
+        final List<String> result = Collections.emptyList();
+        // simulate tab-complete for a name that does not match "f"
+        boolean found = false;
+        for (final TeamsSubcommand s : TeamsAPI.getSubcommands()) {
+            if (s.getName().equalsIgnoreCase("unknowncommand")) {
+                found = true;
+            }
+        }
+
+        assertFalse(found);
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamClaimEventTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/event/TeamClaimEventTest.java
@@ -1,0 +1,301 @@
+package com.skyblockexp.teamsapi.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.skyblockexp.teamsapi.model.Team;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+/**
+ * Unit tests for the team chunk-claim events:
+ * {@link TeamClaimEvent} and {@link TeamUnclaimEvent}.
+ *
+ * <p>Tests verify constructors, getters, cancellable behaviour, and that each event
+ * exposes the correct static {@link org.bukkit.event.HandlerList}.</p>
+ */
+class TeamClaimEventTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamClaimEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamClaimEvent_getTeam_returnsTeam verifies that {@link TeamClaimEvent#getTeam()}
+     * returns the team passed to the constructor.
+     */
+    @Test
+    void teamClaimEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final TeamClaimEvent event = new TeamClaimEvent(team, UUID.randomUUID(), "world", 0, 0);
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamClaimEvent_getPlayerUUID_returnsUUID verifies that
+     * {@link TeamClaimEvent#getPlayerUUID()} returns the player UUID passed to the constructor.
+     */
+    @Test
+    void teamClaimEvent_getPlayerUUID_returnsUUID() {
+        final UUID playerUUID = UUID.randomUUID();
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), playerUUID, "world", 0, 0);
+
+        assertEquals(playerUUID, event.getPlayerUUID());
+    }
+
+    /**
+     * teamClaimEvent_getWorldName_returnsWorldName verifies that
+     * {@link TeamClaimEvent#getWorldName()} returns the world name passed to the constructor.
+     */
+    @Test
+    void teamClaimEvent_getWorldName_returnsWorldName() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "nether", 0, 0);
+
+        assertEquals("nether", event.getWorldName());
+    }
+
+    /**
+     * teamClaimEvent_getChunkX_returnsChunkX verifies that
+     * {@link TeamClaimEvent#getChunkX()} returns the chunk X coordinate passed to the constructor.
+     */
+    @Test
+    void teamClaimEvent_getChunkX_returnsChunkX() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 42, 0);
+
+        assertEquals(42, event.getChunkX());
+    }
+
+    /**
+     * teamClaimEvent_getChunkZ_returnsChunkZ verifies that
+     * {@link TeamClaimEvent#getChunkZ()} returns the chunk Z coordinate passed to the constructor.
+     */
+    @Test
+    void teamClaimEvent_getChunkZ_returnsChunkZ() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, -7);
+
+        assertEquals(-7, event.getChunkZ());
+    }
+
+    /**
+     * teamClaimEvent_isCancelled_returnsFalse_byDefault verifies that
+     * {@link TeamClaimEvent} is not cancelled by default.
+     */
+    @Test
+    void teamClaimEvent_isCancelled_returnsFalse_byDefault() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamClaimEvent_setCancelled_returnsTrue_whenCancelled verifies that cancelling
+     * a {@link TeamClaimEvent} causes {@link TeamClaimEvent#isCancelled()} to return
+     * {@code true}.
+     */
+    @Test
+    void teamClaimEvent_setCancelled_returnsTrue_whenCancelled() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    /**
+     * teamClaimEvent_setCancelled_false_afterTrue_returnsFalse verifies that
+     * cancellation can be reversed on a {@link TeamClaimEvent}.
+     */
+    @Test
+    void teamClaimEvent_setCancelled_false_afterTrue_returnsFalse() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+        event.setCancelled(true);
+
+        event.setCancelled(false);
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamClaimEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamClaimEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamClaimEvent.getHandlerList());
+    }
+
+    /**
+     * teamClaimEvent_getHandlers_isNotNull verifies that the instance
+     * {@code getHandlers()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamClaimEvent_getHandlers_isNotNull() {
+        final TeamClaimEvent event = new TeamClaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        assertNotNull(event.getHandlers());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamUnclaimEvent
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamUnclaimEvent_getTeam_returnsTeam verifies that {@link TeamUnclaimEvent#getTeam()}
+     * returns the team passed to the constructor.
+     */
+    @Test
+    void teamUnclaimEvent_getTeam_returnsTeam() {
+        final Team team = mock(Team.class);
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            team, UUID.randomUUID(), "world", 0, 0);
+
+        assertEquals(team, event.getTeam());
+    }
+
+    /**
+     * teamUnclaimEvent_getPlayerUUID_returnsUUID verifies that
+     * {@link TeamUnclaimEvent#getPlayerUUID()} returns the player UUID passed to the constructor.
+     */
+    @Test
+    void teamUnclaimEvent_getPlayerUUID_returnsUUID() {
+        final UUID playerUUID = UUID.randomUUID();
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), playerUUID, "world", 0, 0);
+
+        assertEquals(playerUUID, event.getPlayerUUID());
+    }
+
+    /**
+     * teamUnclaimEvent_getWorldName_returnsWorldName verifies that
+     * {@link TeamUnclaimEvent#getWorldName()} returns the world name passed to the constructor.
+     */
+    @Test
+    void teamUnclaimEvent_getWorldName_returnsWorldName() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "end", 1, 2);
+
+        assertEquals("end", event.getWorldName());
+    }
+
+    /**
+     * teamUnclaimEvent_getChunkX_returnsChunkX verifies that
+     * {@link TeamUnclaimEvent#getChunkX()} returns the chunk X coordinate.
+     */
+    @Test
+    void teamUnclaimEvent_getChunkX_returnsChunkX() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 99, 0);
+
+        assertEquals(99, event.getChunkX());
+    }
+
+    /**
+     * teamUnclaimEvent_getChunkZ_returnsChunkZ verifies that
+     * {@link TeamUnclaimEvent#getChunkZ()} returns the chunk Z coordinate.
+     */
+    @Test
+    void teamUnclaimEvent_getChunkZ_returnsChunkZ() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, -99);
+
+        assertEquals(-99, event.getChunkZ());
+    }
+
+    /**
+     * teamUnclaimEvent_isCancelled_returnsFalse_byDefault verifies that
+     * {@link TeamUnclaimEvent} is not cancelled by default.
+     */
+    @Test
+    void teamUnclaimEvent_isCancelled_returnsFalse_byDefault() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamUnclaimEvent_setCancelled_returnsTrue_whenCancelled verifies that cancelling
+     * a {@link TeamUnclaimEvent} causes {@link TeamUnclaimEvent#isCancelled()} to return
+     * {@code true}.
+     */
+    @Test
+    void teamUnclaimEvent_setCancelled_returnsTrue_whenCancelled() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+
+    /**
+     * teamUnclaimEvent_setCancelled_false_afterTrue_returnsFalse verifies that
+     * cancellation can be reversed on a {@link TeamUnclaimEvent}.
+     */
+    @Test
+    void teamUnclaimEvent_setCancelled_false_afterTrue_returnsFalse() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+        event.setCancelled(true);
+
+        event.setCancelled(false);
+
+        assertFalse(event.isCancelled());
+    }
+
+    /**
+     * teamUnclaimEvent_getHandlerList_isNotNull verifies that the static
+     * {@code getHandlerList()} returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamUnclaimEvent_getHandlerList_isNotNull() {
+        assertNotNull(TeamUnclaimEvent.getHandlerList());
+    }
+
+    /**
+     * teamUnclaimEvent_getHandlers_isNotNull verifies that the instance
+     * {@code getHandlers()} method returns a non-null {@link org.bukkit.event.HandlerList}.
+     */
+    @Test
+    void teamUnclaimEvent_getHandlers_isNotNull() {
+        final TeamUnclaimEvent event = new TeamUnclaimEvent(
+            mock(Team.class), UUID.randomUUID(), "world", 0, 0);
+
+        assertNotNull(event.getHandlers());
+    }
+
+}


### PR DESCRIPTION
### Added

- `TeamsSubcommand` interface: providers can register custom subcommands under
  `/teamsapi <name>` via `TeamsAPI.registerSubcommand(plugin, subcommand)`. Each
  subcommand declares a `getName()`, `getDescription()`, optional `getPermission()`,
  and `execute(CommandSender, String[])`.
- `TeamsAPI.registerSubcommand(plugin, subcommand)` — registers via Bukkit ServicesManager.
- `TeamsAPI.unregisterSubcommand(subcommand)` — unregisters; call from `onDisable`.
- `TeamsAPI.getSubcommands()` — returns all registered subcommands as a snapshot.
- `/teamsapi status` — player-accessible (no admin permission required); shows the
  active provider, team count, and which optional services (invites, warps, claims,
  power) are registered.
- `/teamsapi info` now shows all five registered service types (TeamsService,
  InviteService, WarpService, ClaimService, PowerService) and the registered
  subcommand count.
- `teamsapi.use` permission (default: `true`) — basic access to `/teamsapi`.
- `teamsapi.status` permission (default: `true`) — access to `/teamsapi status`.

### Changed

- `/teamsapi` now requires `teamsapi.use`; senders without it receive a permission
  error instead of the help message.
- `/teamsapi status` now requires `teamsapi.status`.
- `/teamsapi info` now requires `teamsapi.admin`.
- `/teamsapi help` (and the bare `/teamsapi`) only lists subcommands that the
  sender has permission to execute.