### PR TITLE
Optional TeamsRelationService provider for inter-team relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.0]
+
+### Added
+
+- `TeamRelation` enum (`ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`) — models the declared
+  relationship one team holds toward another. Includes `isFriendly()`, `isHostile()`,
+  and `isMoreHostileThan(other)` helpers.
+- `TeamsRelationService` interface: optional extension service for inter-team relation
+  management. Methods: `setRelation(fromTeamId, toTeamId, relation, initiatorUUID)`,
+  `getRelation(fromTeamId, toTeamId)` (defaults to `NEUTRAL`), `getRelations(teamId)`
+  (returns all non-neutral relations as an unmodifiable map), `clearRelations(teamId)`
+  (for use on team disband). Default methods: `areAllies(teamAId, teamBId)` (mutual
+  ALLY required), `areEnemies(teamAId, teamBId)` (either side suffices).
+- `TeamRelationChangeEvent` (cancellable): fired before a team's declared relation
+  toward another changes. Exposes `getTargetTeam()`, `getInitiatorUUID()`,
+  `getOldRelation()`, `getNewRelation()`, and `setNewRelation()` so listeners can
+  override the incoming relation before it is persisted.
+- `TeamsAPI` facade methods: `getRelationService()`, `isRelationAvailable()`,
+  `registerRelationProvider(plugin, service)`,
+  `registerRelationProvider(plugin, service, priority)`,
+  `unregisterRelationProvider(service)`.
+- `TeamsAPI.API_VERSION` bumped to `1.6.0`.
+
 ## [1.5.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 ```
 
@@ -206,7 +206,47 @@ public void onDisable() {
 }
 ```
 
-### Custom subcommands
+### Relation service (optional)
+
+If the active team plugin supports inter-team diplomacy, a `TeamsRelationService` is
+available. Relations are directional — team A can declare `ALLY` toward team B
+independently of what team B declares toward team A.
+
+```java
+if (TeamsAPI.isRelationAvailable()) {
+    TeamsRelationService relations = TeamsAPI.getRelationService();
+
+    // Declare an alliance
+    relations.setRelation(myTeamId, theirTeamId, TeamRelation.ALLY, player.getUniqueId());
+
+    // Query the current relation
+    TeamRelation rel = relations.getRelation(myTeamId, theirTeamId);
+    player.sendMessage("Relation: " + rel.name());
+
+    // Convenience helpers (mutual check)
+    if (relations.areAllies(myTeamId, theirTeamId)) {
+        player.sendMessage("You are mutual allies!");
+    }
+}
+```
+
+Providers that support relations register the service alongside `TeamsService`:
+
+```java
+@Override
+public void onEnable() {
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerRelationProvider(this, relationService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterRelationProvider(relationService);
+}
+```
+
+`TeamRelation` values (lowest → highest hostility): `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`.
 
 Any plugin can register a `TeamsSubcommand` via `TeamsAPI.registerSubcommand()`. Team
 plugins call `TeamsAPI.getSubcommands()` in their own command executor to dispatch them,

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,16 @@ Entry point for all API interactions. All methods are static.
 | `registerPowerProvider(plugin, service, priority)` | Registers a power provider at the given priority. |
 | `unregisterPowerProvider(service)` | Unregisters a power provider from Bukkit's ServicesManager. |
 
+**Relation service**
+
+| Method | Description |
+|--------|-------------|
+| `getRelationService()` | Returns the active `TeamsRelationService`, or `null` if none is registered. |
+| `isRelationAvailable()` | Returns `true` when a relation provider is registered. |
+| `registerRelationProvider(plugin, service)` | Registers a relation provider at `ServicePriority.Normal`. |
+| `registerRelationProvider(plugin, service, priority)` | Registers a relation provider at the given priority. |
+| `unregisterRelationProvider(service)` | Unregisters a relation provider from Bukkit's ServicesManager. |
+
 **Custom subcommands**
 
 | Method | Description |
@@ -189,6 +199,25 @@ How power is gained, lost, and used to gate land claims is entirely up to the pr
 | `getTeamPower(teamId)` | `double` | Total power for the team (typically sum of member power plus any boost). `0.0` if the team is unknown. |
 | `getTeamMaxPower(teamId)` | `double` | Theoretical maximum power for the team (typically `maxPowerPerPlayer * memberCount`). `0.0` if the team is unknown. |
 
+## `TeamsRelationService` (interface)
+
+Optional extension service for inter-team relation management. Providers that
+support faction-style ally/enemy diplomacy register an implementation via
+`TeamsAPI.registerRelationProvider()`. Existing `TeamsService` implementations are
+not required to support it.
+
+Relations are directional: team A may declare `ALLY` toward team B before team B has
+responded. Whether a relation requires mutual agreement for benefits is provider-defined.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setRelation(fromTeamId, toTeamId, relation, initiatorUUID)` | `boolean` | Declares a relation from one team toward another. Providers should fire `TeamRelationChangeEvent` before persisting; return `false` if cancelled or either team does not exist. Setting `NEUTRAL` removes a previously declared relation. |
+| `getRelation(fromTeamId, toTeamId)` | `TeamRelation` | Returns the relation declared by `fromTeam` toward `toTeam`. Returns `NEUTRAL` if no explicit relation exists. |
+| `getRelations(teamId)` | `Map<UUID, TeamRelation>` | Returns all non-neutral relations declared by the team. Never `null`; empty if no relations exist. |
+| `clearRelations(teamId)` | `boolean` | Removes all relations declared by or toward the team (e.g. on disband). Returns `false` if the team had no relations. |
+| `areAllies(teamAId, teamBId)` | `boolean` | Default: returns `true` when both teams have declared `ALLY` toward each other. |
+| `areEnemies(teamAId, teamBId)` | `boolean` | Default: returns `true` when either team has declared `ENEMY` toward the other. |
+
 ## `Team` (interface)
 
 A read-only snapshot of a team. Obtain via `TeamsService` lookup methods.
@@ -243,6 +272,26 @@ methods.
 | `getChunkZ()` | `int` | The Z coordinate of the claimed chunk. |
 | `getClaimedAt()` | `Instant` | When the chunk was claimed; may be `Instant.EPOCH` if the provider does not track this. |
 
+## `TeamRelation` (enum)
+
+Represents the relationship one team has declared toward another. Ordinal ordering
+(lowest hostility → highest): `ALLY < TRUCE < NEUTRAL < ENEMY`.
+
+| Constant | Description |
+|----------|-------------|
+| `ALLY`    | Formal alliance — mutual benefits apply. |
+| `TRUCE`   | Agreed ceasefire — no active hostility. |
+| `NEUTRAL` | No formal relation (default when none is set). |
+| `ENEMY`   | Actively hostile. |
+
+Helper methods:
+
+| Method | Description |
+|--------|-------------|
+| `isFriendly()` | Returns `true` for `ALLY` and `TRUCE`. |
+| `isHostile()` | Returns `true` for `ENEMY`. |
+| `isMoreHostileThan(other)` | Returns `true` if this relation has a higher hostility level than `other`. |
+
 ## `TeamRole` (enum)
 
 | Constant | Priority | Description |
@@ -296,9 +345,28 @@ All concrete events implement `Cancellable`.
 | `TeamClaimEvent` | Yes | `getTeam()`, `getPlayerUUID()`, `getWorldName()`, `getChunkX()`, `getChunkZ()` |
 | `TeamUnclaimEvent` | Yes | `getTeam()`, `getPlayerUUID()`, `getWorldName()`, `getChunkX()`, `getChunkZ()` |
 
+**Relation events**
+
+| Class | Cancellable | Key fields |
+|-------|-------------|------------|
+| `TeamRelationChangeEvent` | Yes | `getTeam()` (source), `getTargetTeam()`, `getInitiatorUUID()`, `getOldRelation()`, `getNewRelation()`, `setNewRelation(relation)` |
+
 ## Migration notes
 
-### 1.4.0
+### 1.6.0
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- New `TeamRelation` enum: `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY` with `isFriendly()`,
+  `isHostile()`, and `isMoreHostileThan(other)` helpers.
+- New optional `TeamsRelationService` interface for inter-team relation management.
+- New `TeamsAPI` static methods: `getRelationService()`, `isRelationAvailable()`,
+  `registerRelationProvider(...)`, `unregisterRelationProvider(...)`.
+- New event: `TeamRelationChangeEvent` (cancellable). Exposes `setNewRelation()` so
+  listeners can override the incoming relation before it is persisted.
+- `TeamsAPI.API_VERSION` bumped from `1.5.0` to `1.6.0`.
+
+### 1.5.0
 
 Non-breaking addition. No changes required for existing providers or consumers.
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -29,6 +29,7 @@ consumer plugin keeps working without a recompile.
 - **Optional warp service**: providers can expose `TeamsWarpService` for named team warps.
 - **Optional claim service**: providers can expose `TeamsClaimService` for chunk-claim management.
 - **Optional power service**: providers can expose `TeamsPowerService` for player and team power values.
+- **Optional relation service**: providers can expose `TeamsRelationService` for inter-team diplomacy (ally/truce/neutral/enemy).
 - **Custom subcommands**: any plugin registers a `TeamsSubcommand` via `TeamsAPI.registerSubcommand()`; team plugins call `TeamsAPI.getSubcommands()` in their own command handler to dispatch them, extending the command tree without coupling.
 - **Cancellable events**: twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 - **Lightweight**: a single shaded JAR with no runtime dependencies beyond the Bukkit API.
@@ -71,7 +72,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -83,7 +84,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 ```
 
@@ -232,6 +233,27 @@ TeamsAPI.registerPowerProvider(this, powerService);
 | `getTeamMaxPower(teamId)` | `double` | Maximum combined power the team can hold |
 
 Consumers check availability with `TeamsAPI.isPowerAvailable()` before calling `TeamsAPI.getPowerService()`.
+
+### Relation service (optional)
+
+Register alongside `TeamsService` if your plugin supports inter-team diplomacy:
+
+```java
+TeamsAPI.registerRelationProvider(this, relationService);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setRelation(fromTeamId, toTeamId, relation, initiatorUUID)` | `boolean` | Declares a relation from one team toward another. Fires `TeamRelationChangeEvent`; returns `false` if cancelled. Setting `NEUTRAL` removes the relation. |
+| `getRelation(fromTeamId, toTeamId)` | `TeamRelation` | Returns the declared relation (defaults to `NEUTRAL` if none is set). |
+| `getRelations(teamId)` | `Map<UUID, TeamRelation>` | All non-neutral relations declared by the team. |
+| `clearRelations(teamId)` | `boolean` | Removes all relations declared by or toward the team (use on disband). |
+| `areAllies(teamAId, teamBId)` | `boolean` | Returns `true` when both teams have declared `ALLY` toward each other. |
+| `areEnemies(teamAId, teamBId)` | `boolean` | Returns `true` when either team has declared `ENEMY` toward the other. |
+
+`TeamRelation` values (lowest → highest hostility): `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`.
+
+Consumers check availability with `TeamsAPI.isRelationAvailable()` before calling `TeamsAPI.getRelationService()`.
 
 ### Custom subcommands
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -30,6 +30,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 [*][B]Optional warp service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsWarpService[/COLOR] for named team warps.
 [*][B]Optional claim service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsClaimService[/COLOR] for chunk-claim management.
 [*][B]Optional power service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsPowerService[/COLOR] for player and team power values.
+[*][B]Optional relation service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsRelationService[/COLOR] for inter-team diplomacy (ally / truce / neutral / enemy).
 [*][B]Custom subcommands[/B] -- any plugin registers a [COLOR=#6cb4ff]TeamsSubcommand[/COLOR] via [COLOR=#6cb4ff]TeamsAPI.registerSubcommand()[/COLOR]; team plugins call [COLOR=#6cb4ff]TeamsAPI.getSubcommands()[/COLOR] in their own command handler to dispatch them without coupling.
 [*][B]Cancellable events[/B] -- twelve Bukkit events that providers can fire so other plugins can react to or cancel team operations.
 [*][B]Lightweight[/B] -- a single shaded JAR with no runtime dependencies beyond the Bukkit API.
@@ -75,7 +76,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -87,7 +88,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.5.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
 }
 [/CODE]
 [/SPOILER]
@@ -211,6 +212,21 @@ public void onDisable() {
 [*][COLOR=#6cb4ff]getTeamPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Combined power of all team members
 [*][COLOR=#6cb4ff]getTeamMaxPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Maximum combined power the team can hold
 [/LIST]
+
+[SIZE=4][B]Relation service (optional)[/B][/SIZE]
+
+[COLOR=#aaaaaa]Check availability with [COLOR=#6cb4ff]TeamsAPI.isRelationAvailable()[/COLOR] before calling [COLOR=#6cb4ff]TeamsAPI.getRelationService()[/COLOR].[/COLOR]
+
+[LIST]
+[*][COLOR=#6cb4ff]setRelation(fromTeamId, toTeamId, relation, initiatorUUID)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Declares a relation toward another team. Fires [COLOR=#6cb4ff]TeamRelationChangeEvent[/COLOR]; returns [COLOR=#f08080]false[/COLOR] if cancelled. Setting [COLOR=#ffd700]NEUTRAL[/COLOR] removes the relation.
+[*][COLOR=#6cb4ff]getRelation(fromTeamId, toTeamId)[/COLOR] -> [COLOR=#ffd700]TeamRelation[/COLOR] -- Returns the declared relation (defaults to [COLOR=#ffd700]NEUTRAL[/COLOR] if none set).
+[*][COLOR=#6cb4ff]getRelations(teamId)[/COLOR] -> [COLOR=#ffd700]Map<UUID, TeamRelation>[/COLOR] -- All non-neutral relations declared by the team.
+[*][COLOR=#6cb4ff]clearRelations(teamId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Removes all relations declared by or toward the team (use on disband).
+[*][COLOR=#6cb4ff]areAllies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when both teams have declared [COLOR=#ffd700]ALLY[/COLOR] toward each other.
+[*][COLOR=#6cb4ff]areEnemies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when either team has declared [COLOR=#ffd700]ENEMY[/COLOR] toward the other.
+[/LIST]
+
+[COLOR=#aaaaaa]TeamRelation values (lowest → highest hostility): [COLOR=#ffd700]ALLY[/COLOR], [COLOR=#ffd700]TRUCE[/COLOR], [COLOR=#ffd700]NEUTRAL[/COLOR], [COLOR=#ffd700]ENEMY[/COLOR].[/COLOR]
 
 [SIZE=4][B]Custom subcommands[/B][/SIZE]
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -52,7 +52,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.5.0";
+    public static final String API_VERSION = "1.6.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }
@@ -534,6 +534,102 @@ public final class TeamsAPI {
         }
 
         Bukkit.getServicesManager().unregister(TeamsPowerService.class, provider);
+    }
+
+    // -------------------------------------------------------------------------
+    // Relation provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsRelationService} provider, or
+     * {@code null} if no relation provider has been registered.
+     *
+     * <p>Consumers should check {@link #isRelationAvailable()} before calling this
+     * method to handle gracefully the case where no team plugin exposes inter-team
+     * relations.</p>
+     *
+     * @return the active {@link TeamsRelationService}, or {@code null} if unavailable
+     */
+    public static TeamsRelationService getRelationService() {
+        try {
+            final RegisteredServiceProvider<TeamsRelationService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsRelationService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsRelationService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if a relation provider is available, {@code false} otherwise
+     */
+    public static boolean isRelationAvailable() {
+        return getRelationService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsRelationService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsRelationService} implementation; must not be {@code null}
+     */
+    public static void registerRelationProvider(final Plugin plugin,
+            final TeamsRelationService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsRelationService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsRelationService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsRelationService} implementation; must not be {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerRelationProvider(
+            final Plugin plugin,
+            final TeamsRelationService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsRelationService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsRelationService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsRelationService} provider to unregister; may be {@code null}
+     */
+    public static void unregisterRelationProvider(final TeamsRelationService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsRelationService.class, provider);
     }
 
     // -------------------------------------------------------------------------

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
@@ -1,0 +1,138 @@
+package com.skyblockexp.teamsapi.api;
+
+import com.skyblockexp.teamsapi.model.TeamRelation;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Optional extension service for inter-team relation management.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to
+ * expose inter-team relations (allies, truces, enemies) register an implementation
+ * separately via
+ * {@link TeamsAPI#registerRelationProvider(org.bukkit.plugin.Plugin, TeamsRelationService)}.
+ * Consumers first check whether the service is available with
+ * {@link TeamsAPI#isRelationAvailable()} before calling
+ * {@link TeamsAPI#getRelationService()}.</p>
+ *
+ * <p>Existing {@link TeamsService} implementations are not required to implement this
+ * interface; omitting it is a supported configuration and the API will degrade
+ * gracefully.</p>
+ *
+ * <p>Relations model directional declarations: team A may declare
+ * {@link TeamRelation#ALLY} toward team B while team B has not yet responded.
+ * Whether a relation is considered active (e.g. mutual ALLY required for benefits)
+ * is entirely up to the provider.</p>
+ *
+ * <p><strong>Provider registration example:</strong></p>
+ * <pre>{@code
+ * // In your team plugin's onEnable():
+ * TeamsAPI.registerRelationProvider(this, new MyRelationServiceImpl());
+ *
+ * // In your team plugin's onDisable():
+ * TeamsAPI.unregisterRelationProvider(myRelationService);
+ * }</pre>
+ *
+ * <p><strong>Consumer usage example:</strong></p>
+ * <pre>{@code
+ * TeamsRelationService relations = TeamsAPI.getRelationService();
+ * if (relations == null) {
+ *     player.sendMessage("Relations are not supported by the active team plugin.");
+ *     return;
+ * }
+ * TeamRelation rel = relations.getRelation(teamAId, teamBId);
+ * if (rel == TeamRelation.ENEMY) {
+ *     player.sendMessage("Warning: you are entering enemy territory.");
+ * }
+ * }</pre>
+ */
+public interface TeamsRelationService {
+
+    /**
+     * Sets the relation that {@code fromTeamId} declares toward {@code toTeamId}.
+     *
+     * <p>Providers should fire
+     * {@link com.skyblockexp.teamsapi.event.TeamRelationChangeEvent} before
+     * persisting the change. If the event is cancelled, implementations should
+     * return {@code false}.</p>
+     *
+     * <p>Setting a relation to {@link TeamRelation#NEUTRAL} is equivalent to
+     * removing a previously declared relation.</p>
+     *
+     * @param fromTeamId    the UUID of the team making the declaration; must not be {@code null}
+     * @param toTeamId      the UUID of the team being targeted; must not be {@code null}
+     * @param relation      the {@link TeamRelation} to declare; must not be {@code null}
+     * @param initiatorUUID the UUID of the player initiating the change; must not be {@code null}
+     * @return {@code true} if the relation was successfully recorded, {@code false}
+     *         otherwise (e.g. either team does not exist or the event was cancelled)
+     */
+    boolean setRelation(UUID fromTeamId, UUID toTeamId, TeamRelation relation, UUID initiatorUUID);
+
+    /**
+     * Returns the relation that {@code fromTeamId} has declared toward {@code toTeamId}.
+     *
+     * <p>If no explicit relation has been set, {@link TeamRelation#NEUTRAL} is returned.</p>
+     *
+     * @param fromTeamId the UUID of the team whose declaration is queried; must not be {@code null}
+     * @param toTeamId   the UUID of the target team; must not be {@code null}
+     * @return the declared {@link TeamRelation}; never {@code null};
+     *         {@link TeamRelation#NEUTRAL} if no relation has been set
+     */
+    TeamRelation getRelation(UUID fromTeamId, UUID toTeamId);
+
+    /**
+     * Returns all non-neutral relations declared by the given team.
+     *
+     * <p>The returned map's keys are the UUIDs of the target teams; values are the
+     * corresponding {@link TeamRelation}. Entries with {@link TeamRelation#NEUTRAL}
+     * are excluded.</p>
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @return an unmodifiable map of active relations; never {@code null},
+     *         empty if the team has no explicit relations or does not exist
+     */
+    Map<UUID, TeamRelation> getRelations(UUID teamId);
+
+    /**
+     * Removes all relations declared by or toward the given team.
+     *
+     * <p>This method is intended for use when a team is disbanded. Individual relation
+     * change events are not required to be fired per relation; implementations may
+     * batch the removal.</p>
+     *
+     * @param teamId the UUID of the team whose relations should be cleared; must not be {@code null}
+     * @return {@code true} if any relations existed and were removed,
+     *         {@code false} if the team had no recorded relations
+     */
+    boolean clearRelations(UUID teamId);
+
+    /**
+     * Returns {@code true} if both teams have declared {@link TeamRelation#ALLY}
+     * toward each other.
+     *
+     * <p>This default implementation requires mutual ALLY declarations. Providers
+     * may override this method to apply different symmetry rules.</p>
+     *
+     * @param teamAId the UUID of the first team; must not be {@code null}
+     * @param teamBId the UUID of the second team; must not be {@code null}
+     * @return {@code true} if both teams have declared ALLY, {@code false} otherwise
+     */
+    default boolean areAllies(final UUID teamAId, final UUID teamBId) {
+        return getRelation(teamAId, teamBId) == TeamRelation.ALLY
+            && getRelation(teamBId, teamAId) == TeamRelation.ALLY;
+    }
+
+    /**
+     * Returns {@code true} if either team has declared {@link TeamRelation#ENEMY}
+     * toward the other.
+     *
+     * @param teamAId the UUID of the first team; must not be {@code null}
+     * @param teamBId the UUID of the second team; must not be {@code null}
+     * @return {@code true} if either team considers the other an enemy, {@code false} otherwise
+     */
+    default boolean areEnemies(final UUID teamAId, final UUID teamBId) {
+        return getRelation(teamAId, teamBId) == TeamRelation.ENEMY
+            || getRelation(teamBId, teamAId) == TeamRelation.ENEMY;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamRelationChangeEvent.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/event/TeamRelationChangeEvent.java
@@ -1,0 +1,147 @@
+package com.skyblockexp.teamsapi.event;
+
+import com.skyblockexp.teamsapi.model.Team;
+import com.skyblockexp.teamsapi.model.TeamRelation;
+
+import java.util.UUID;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a team is about to change its declared relation toward another team.
+ *
+ * <p>Providers should fire this event before persisting the relation change. If the
+ * event is cancelled, the change must not be recorded and
+ * {@link com.skyblockexp.teamsapi.api.TeamsRelationService#setRelation} should
+ * return {@code false}.</p>
+ *
+ * <p>Listeners may also modify the declared relation via {@link #setNewRelation} to
+ * override the value before the provider persists it.</p>
+ */
+public class TeamRelationChangeEvent extends TeamEvent implements Cancellable {
+
+    /** Shared handler list for this event type. */
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    /** The team that the relation is declared toward. */
+    private final Team targetTeam;
+
+    /** The UUID of the player who initiated the relation change. */
+    private final UUID initiatorUUID;
+
+    /** The relation the source team previously held toward the target team. */
+    private final TeamRelation oldRelation;
+
+    /** The new relation being declared; may be modified by listeners. */
+    private TeamRelation newRelation;
+
+    /** Whether this event has been cancelled. */
+    private boolean cancelled;
+
+    /**
+     * Creates a new {@link TeamRelationChangeEvent}.
+     *
+     * @param fromTeam      the team making the declaration; must not be {@code null}
+     * @param targetTeam    the team being targeted; must not be {@code null}
+     * @param initiatorUUID the UUID of the player initiating the change; must not be {@code null}
+     * @param oldRelation   the previous relation; must not be {@code null}
+     * @param newRelation   the new relation being declared; must not be {@code null}
+     */
+    public TeamRelationChangeEvent(
+            final Team fromTeam,
+            final Team targetTeam,
+            final UUID initiatorUUID,
+            final TeamRelation oldRelation,
+            final TeamRelation newRelation) {
+        super(fromTeam);
+        this.targetTeam = targetTeam;
+        this.initiatorUUID = initiatorUUID;
+        this.oldRelation = oldRelation;
+        this.newRelation = newRelation;
+    }
+
+    /**
+     * Returns the team that this relation is declared toward.
+     *
+     * @return the target {@link Team}; never {@code null}
+     */
+    public Team getTargetTeam() {
+        return targetTeam;
+    }
+
+    /**
+     * Returns the UUID of the player who initiated the relation change.
+     *
+     * @return the initiator's UUID; never {@code null}
+     */
+    public UUID getInitiatorUUID() {
+        return initiatorUUID;
+    }
+
+    /**
+     * Returns the relation previously held by the source team toward the target team.
+     *
+     * @return the old {@link TeamRelation}; never {@code null}
+     */
+    public TeamRelation getOldRelation() {
+        return oldRelation;
+    }
+
+    /**
+     * Returns the new relation being declared.
+     *
+     * <p>Listeners may change this value via {@link #setNewRelation} to override
+     * the declared relation before the provider persists it.</p>
+     *
+     * @return the new {@link TeamRelation}; never {@code null}
+     */
+    public TeamRelation getNewRelation() {
+        return newRelation;
+    }
+
+    /**
+     * Overrides the new relation to a different value.
+     *
+     * <p>Providers must read back this value after firing the event and use it
+     * instead of the originally requested relation.</p>
+     *
+     * @param newRelation the replacement relation; must not be {@code null}
+     */
+    public void setNewRelation(final TeamRelation newRelation) {
+        this.newRelation = newRelation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(final boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the static handler list for this event type.
+     *
+     * @return the handler list
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
@@ -1,0 +1,69 @@
+package com.skyblockexp.teamsapi.model;
+
+/**
+ * Represents the relationship that one team has declared toward another.
+ *
+ * <p>Relations are used by faction-style plugins to model alliances, truces, and
+ * hostility between teams. The default state when no relation has been explicitly
+ * set is {@link #NEUTRAL}.</p>
+ *
+ * <p>Ordinal ordering (lowest hostility → highest hostility):
+ * {@code ALLY < TRUCE < NEUTRAL < ENEMY}</p>
+ *
+ * <p>Relations may be directional or symmetric depending on the provider.
+ * Consumers should use {@link com.skyblockexp.teamsapi.api.TeamsRelationService}
+ * to query and manage relations.</p>
+ */
+public enum TeamRelation {
+
+    /** The two teams are formal allies — mutual benefits apply. */
+    ALLY,
+
+    /** The two teams have agreed to a temporary truce — no active hostility. */
+    TRUCE,
+
+    /**
+     * No formal relation has been set; neither friendly nor hostile.
+     * This is the default state returned when no explicit relation exists.
+     */
+    NEUTRAL,
+
+    /** The two teams are actively hostile toward each other. */
+    ENEMY;
+
+    // -------------------------------------------------------------------------
+    // Convenience helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if this relation is considered friendly
+     * (i.e. {@link #ALLY} or {@link #TRUCE}).
+     *
+     * @return {@code true} for ALLY and TRUCE, {@code false} otherwise
+     */
+    public boolean isFriendly() {
+        return this == ALLY || this == TRUCE;
+    }
+
+    /**
+     * Returns {@code true} if this relation is considered hostile
+     * (i.e. {@link #ENEMY}).
+     *
+     * @return {@code true} for ENEMY, {@code false} otherwise
+     */
+    public boolean isHostile() {
+        return this == ENEMY;
+    }
+
+    /**
+     * Returns {@code true} if this relation has a higher hostility level than {@code other}.
+     *
+     * <p>Hostility ordering: ALLY &lt; TRUCE &lt; NEUTRAL &lt; ENEMY.</p>
+     *
+     * @param other the relation to compare against; must not be {@code null}
+     * @return {@code true} if this relation is more hostile than {@code other}
+     */
+    public boolean isMoreHostileThan(final TeamRelation other) {
+        return this.ordinal() > other.ordinal();
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
@@ -1,0 +1,175 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsRelationService} registration methods on {@link TeamsAPI}.
+ *
+ * <p>Tests verify that the relation service facade correctly delegates to Bukkit's
+ * ServicesManager and that null-safety contracts hold, mirroring
+ * {@link TeamsAPIClaimTest}.</p>
+ */
+class TeamsAPIRelationTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isRelationAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isRelationAvailable()} returns {@code false} when no relation
+     * provider has been registered.
+     */
+    @Test
+    void isRelationAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isRelationAvailable());
+    }
+
+    /**
+     * getRelationService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getRelationService()} returns {@code null} when no relation
+     * provider has been registered.
+     */
+    @Test
+    void getRelationService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getRelationService());
+    }
+
+    /**
+     * registerRelationProvider_makesRelationServiceAvailable verifies that after
+     * registering a relation provider, {@link TeamsAPI#isRelationAvailable()} returns
+     * {@code true} and {@link TeamsAPI#getRelationService()} returns the registered
+     * provider.
+     */
+    @Test
+    void registerRelationProvider_makesRelationServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(plugin, mockRelation);
+
+        assertTrue(TeamsAPI.isRelationAvailable());
+        assertEquals(mockRelation, TeamsAPI.getRelationService());
+    }
+
+    /**
+     * unregisterRelationProvider_makesRelationServiceUnavailable verifies that after
+     * unregistering a relation provider, {@link TeamsAPI#isRelationAvailable()} returns
+     * {@code false}.
+     */
+    @Test
+    void unregisterRelationProvider_makesRelationServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(plugin, mockRelation);
+        TeamsAPI.unregisterRelationProvider(mockRelation);
+
+        assertFalse(TeamsAPI.isRelationAvailable());
+    }
+
+    /**
+     * registerRelationProvider_withNullPlugin_doesNotRegister verifies that passing a
+     * {@code null} plugin does not register anything.
+     */
+    @Test
+    void registerRelationProvider_withNullPlugin_doesNotRegister() {
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(null, mockRelation);
+
+        assertFalse(TeamsAPI.isRelationAvailable());
+    }
+
+    /**
+     * registerRelationProvider_withNullProvider_doesNotRegister verifies that passing a
+     * {@code null} provider does not register anything.
+     */
+    @Test
+    void registerRelationProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerRelationProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isRelationAvailable());
+    }
+
+    /**
+     * unregisterRelationProvider_withNull_doesNotThrow verifies that passing {@code null}
+     * to {@link TeamsAPI#unregisterRelationProvider(TeamsRelationService)} does not throw.
+     */
+    @Test
+    void unregisterRelationProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterRelationProvider(null);
+        // No exception expected
+    }
+
+    /**
+     * registerRelationProvider_withPriority_registersCorrectly verifies that the overload
+     * accepting a {@link org.bukkit.plugin.ServicePriority} registers the relation provider
+     * successfully.
+     */
+    @Test
+    void registerRelationProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(plugin, mockRelation,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isRelationAvailable());
+        assertEquals(mockRelation, TeamsAPI.getRelationService());
+    }
+
+    /**
+     * registerRelationProvider_withPriority_withNullPriority_doesNotRegister verifies
+     * that passing a {@code null} priority does not register anything.
+     */
+    @Test
+    void registerRelationProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(plugin, mockRelation, null);
+
+        assertFalse(TeamsAPI.isRelationAvailable());
+    }
+
+    /**
+     * relationService_isIndependentOfTeamsService verifies that registering only a
+     * relation provider does not affect {@link TeamsAPI#isAvailable()}, and vice versa.
+     */
+    @Test
+    void relationService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsRelationService mockRelation = mock(TeamsRelationService.class);
+
+        TeamsAPI.registerRelationProvider(plugin, mockRelation);
+
+        assertTrue(TeamsAPI.isRelationAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}


### PR DESCRIPTION
- Add TeamRelation enum (ALLY, TRUCE, NEUTRAL, ENEMY) with isFriendly(), isHostile(), and isMoreHostileThan() helpers
- Add TeamsRelationService interface: setRelation, getRelation, getRelations, clearRelations, areAllies (default), areEnemies (default)
- Add TeamRelationChangeEvent (cancellable) with setNewRelation() override support
- Wire into TeamsAPI facade: getRelationService, isRelationAvailable, registerRelationProvider (x2), unregisterRelationProvider
- Add TeamsAPIRelationTest (9 tests, all passing)
- Bump TeamsAPI.API_VERSION 1.5.0 -> 1.6.0
- Bump all pom.xml versions to 1.6.0
- Update CHANGELOG, README, docs/api.md, listing/modrinth-hangar.md, listing/spigotmc.bbcode