### PR TITLE
TeamRelation display name/color and getTeamsInRelation helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           java-version: '25'
           cache: maven
 
+      - name: Purge stale JitPack artifacts from Maven cache
+        run: rm -rf ~/.m2/repository/com/github
+
       - name: Run Checkstyle
         run: mvn -B -ntp checkstyle:check
 
@@ -53,6 +56,9 @@ jobs:
           distribution: temurin
           java-version: '25'
           cache: maven
+
+      - name: Purge stale JitPack artifacts from Maven cache
+        run: rm -rf ~/.m2/repository/com/github
 
       - name: Compile, test and coverage
         env:
@@ -83,6 +89,9 @@ jobs:
           distribution: temurin
           java-version: '25'
           cache: maven
+
+      - name: Purge stale JitPack artifacts from Maven cache
+        run: rm -rf ~/.m2/repository/com/github
 
       - name: Package
         run: mvn -B -ntp -DskipTests package

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   smoke:
-    name: Smoke – ${{ matrix.server }} ${{ matrix.mc_version }}
+    name: Smoke – ${{ matrix.server }} ${{ matrix.mc_version }} / Java ${{ matrix.java_version }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -22,19 +22,34 @@ jobs:
         include:
           - server: Paper
             project: paper
-            mc_version: "1.21.4"
+            mc_version: "1.21.11"
+            java_version: '21'
+          - server: Paper
+            project: paper
+            mc_version: "1.21.11"
+            java_version: '25'
           - server: Folia
             project: folia
-            mc_version: "1.21.4"
+            mc_version: "1.21.11"
+            java_version: '21'
+          - server: Folia
+            project: folia
+            mc_version: "1.21.11"
+            java_version: '25'
           - server: Spigot
             project: spigot
-            mc_version: "1.21.4"
+            mc_version: "1.21.11"
+            java_version: '21'
+          - server: Spigot
+            project: spigot
+            mc_version: "1.21.11"
+            java_version: '25'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 25
+      - name: Set up JDK 25 (build)
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -51,6 +66,13 @@ jobs:
             -name "teams-api-plugin-*.jar" ! -name "original-*" | head -1)
           echo "path=$JAR" >> "$GITHUB_OUTPUT"
           echo "Located: $JAR"
+
+      - name: Set up JDK ${{ matrix.java_version }} (server runtime)
+        id: server-jdk
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java_version }}
 
       # ── Paper / Folia ────────────────────────────────────────────────────────
 
@@ -113,9 +135,11 @@ jobs:
       # ── Start server ─────────────────────────────────────────────────────────
 
       - name: Start server and wait for Done
+        env:
+          JAVA_CMD: ${{ steps.server-jdk.outputs.java-home }}/bin/java
         run: |
           cd server
-          java -Xmx512M -Xms512M -jar server.jar --nogui > server.log 2>&1 &
+          "${JAVA_CMD}" -Xmx512M -Xms512M -jar server.jar --nogui > server.log 2>&1 &
           SERVER_PID=$!
           echo "Server PID: ${SERVER_PID}"
 
@@ -162,26 +186,29 @@ jobs:
             exit 1
           fi
 
-          # No SEVERE lines from TeamsAPI
-          if grep -E "SEVERE|ERROR" "${LOG}" | grep -qi "teamsapi"; then
+          # No SEVERE or ERROR lines from TeamsAPI's own logger.
+          # Use the [TeamsAPI] prefix to avoid false positives from the server's
+          # bytecode remapper (Commodore) which may log errors mentioning the
+          # plugin name when processing the MRJAR on newer JVMs.
+          if grep -E 'SEVERE|ERROR' "${LOG}" | grep -q '\[TeamsAPI\]'; then
             echo "::error::TeamsAPI produced a SEVERE or ERROR log entry"
             cat "${LOG}"
             exit 1
           fi
 
-          # No exception stack traces involving TeamsAPI
-          if grep -iE "exception|caused by" "${LOG}" | grep -qi "teamsapi"; then
+          # No exception stack traces from within TeamsAPI's own code
+          if grep -iE 'exception|caused by' "${LOG}" | grep -q '\[TeamsAPI\]'; then
             echo "::error::Exception detected in TeamsAPI context"
             cat "${LOG}"
             exit 1
           fi
 
-          echo "OK – TeamsAPI loaded cleanly on ${{ matrix.server }} ${{ matrix.mc_version }}"
+          echo "OK – TeamsAPI loaded cleanly on ${{ matrix.server }} ${{ matrix.mc_version }} / Java ${{ matrix.java_version }}"
 
       - name: Upload server log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: server-log-${{ matrix.server }}-${{ matrix.mc_version }}
+          name: server-log-${{ matrix.server }}-${{ matrix.mc_version }}-java${{ matrix.java_version }}
           path: server/server.log
           if-no-files-found: ignore

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,6 +56,9 @@ jobs:
           java-version: '25'
           cache: maven
 
+      - name: Purge stale JitPack artifacts from Maven cache
+        run: rm -rf ~/.m2/repository/com/github
+
       - name: Build plugin JAR
         run: mvn -B -ntp -DskipTests package
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,187 @@
+name: Smoke Tests
+
+# Verify that the plugin JAR starts cleanly on Paper, Folia, and Spigot.
+# The test passes when the server reaches its "Done" state and TeamsAPI logs
+# its enabled banner without any SEVERE / exception output.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Smoke – ${{ matrix.server }} ${{ matrix.mc_version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - server: Paper
+            project: paper
+            mc_version: "1.21.4"
+          - server: Folia
+            project: folia
+            mc_version: "1.21.4"
+          - server: Spigot
+            project: spigot
+            mc_version: "1.21.4"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Build plugin JAR
+        run: mvn -B -ntp -DskipTests package
+
+      - name: Locate plugin JAR
+        id: jar
+        run: |
+          JAR=$(find teams-api-plugin/target -maxdepth 1 \
+            -name "teams-api-plugin-*.jar" ! -name "original-*" | head -1)
+          echo "path=$JAR" >> "$GITHUB_OUTPUT"
+          echo "Located: $JAR"
+
+      # ── Paper / Folia ────────────────────────────────────────────────────────
+
+      - name: Download ${{ matrix.server }} ${{ matrix.mc_version }} JAR
+        if: matrix.project != 'spigot'
+        run: |
+          BUILD=$(curl -sf \
+            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['builds'][-1]['build'])")
+          JAR_NAME=$(curl -sf \
+            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds/${BUILD}" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['downloads']['application']['name'])")
+          curl -sfL \
+            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds/${BUILD}/downloads/${JAR_NAME}" \
+            -o server.jar
+          echo "Downloaded ${{ matrix.server }} ${{ matrix.mc_version }} build ${BUILD} (${JAR_NAME})"
+
+      # ── Spigot via BuildTools ────────────────────────────────────────────────
+
+      - name: Cache Spigot ${{ matrix.mc_version }}
+        if: matrix.project == 'spigot'
+        id: cache-spigot
+        uses: actions/cache@v4
+        with:
+          path: ~/.spigot-cache
+          key: spigot-${{ matrix.mc_version }}-buildtools-v1
+
+      - name: Build Spigot via BuildTools
+        if: matrix.project == 'spigot' && steps.cache-spigot.outputs.cache-hit != 'true'
+        run: |
+          git config --global user.email "ci@example.com"
+          git config --global user.name "GitHub Actions CI"
+          mkdir -p ~/.spigot-cache
+          cd ~/.spigot-cache
+          curl -sfL \
+            https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar \
+            -o BuildTools.jar
+          java -jar BuildTools.jar --rev ${{ matrix.mc_version }} --compile SPIGOT 2>&1
+
+      - name: Copy Spigot JAR
+        if: matrix.project == 'spigot'
+        run: cp ~/.spigot-cache/spigot-${{ matrix.mc_version }}.jar server.jar
+
+      # ── Prepare server directory ─────────────────────────────────────────────
+
+      - name: Prepare server
+        run: |
+          mkdir -p server/plugins
+          cp server.jar server/server.jar
+          cp "${{ steps.jar.outputs.path }}" server/plugins/TeamsAPI.jar
+          echo "eula=true" > server/eula.txt
+          {
+            echo "online-mode=false"
+            echo "level-type=flat"
+            echo "generate-structures=false"
+            echo "view-distance=2"
+            echo "simulation-distance=2"
+          } > server/server.properties
+
+      # ── Start server ─────────────────────────────────────────────────────────
+
+      - name: Start server and wait for Done
+        run: |
+          cd server
+          java -Xmx512M -Xms512M -jar server.jar --nogui > server.log 2>&1 &
+          SERVER_PID=$!
+          echo "Server PID: ${SERVER_PID}"
+
+          # Poll every 5 s, up to 3 minutes
+          for i in $(seq 1 36); do
+            if grep -q "Done (" server.log 2>/dev/null; then
+              echo "Server reached Done state after $((i * 5))s"
+              break
+            fi
+            if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+              echo "::error::Server process exited before reaching Done state"
+              cat server.log
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if ! grep -q "Done (" server.log; then
+            echo "::error::Server did not reach Done state within 180s"
+            kill "${SERVER_PID}" 2>/dev/null || true
+            cat server.log
+            exit 1
+          fi
+
+          # Graceful stop
+          kill "${SERVER_PID}"
+          wait "${SERVER_PID}" 2>/dev/null || true
+          echo "Server stopped"
+
+      # ── Assertions ───────────────────────────────────────────────────────────
+
+      - name: Assert TeamsAPI loaded cleanly
+        run: |
+          LOG=server/server.log
+
+          echo "=== TeamsAPI log lines ==="
+          grep -i "teamsapi" "${LOG}" || true
+          echo "=========================="
+
+          # Plugin must have printed its enabled banner
+          if ! grep -q "TeamsAPI v.*enabled\." "${LOG}"; then
+            echo "::error::TeamsAPI enabled banner not found in server log"
+            cat "${LOG}"
+            exit 1
+          fi
+
+          # No SEVERE lines from TeamsAPI
+          if grep -E "SEVERE|ERROR" "${LOG}" | grep -qi "teamsapi"; then
+            echo "::error::TeamsAPI produced a SEVERE or ERROR log entry"
+            cat "${LOG}"
+            exit 1
+          fi
+
+          # No exception stack traces involving TeamsAPI
+          if grep -iE "exception|caused by" "${LOG}" | grep -qi "teamsapi"; then
+            echo "::error::Exception detected in TeamsAPI context"
+            cat "${LOG}"
+            exit 1
+          fi
+
+          echo "OK – TeamsAPI loaded cleanly on ${{ matrix.server }} ${{ matrix.mc_version }}"
+
+      - name: Upload server log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-log-${{ matrix.server }}-${{ matrix.mc_version }}
+          path: server/server.log
+          if-no-files-found: ignore

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,8 @@
 name: Smoke Tests
 
 # Verify that the plugin JAR starts cleanly on Paper, Folia, and Spigot.
-# The test passes when the server reaches its "Done" state and TeamsAPI logs
-# its enabled banner without any SEVERE / exception output.
+# The test passes when the server reaches its "Done" state without TeamsAPI
+# logging an enable-failure or a JVM API-incompatibility error.
 
 on:
   push:
@@ -11,113 +11,148 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  MC_VERSION: "1.21.11"
+
 jobs:
-  smoke:
-    name: Smoke – ${{ matrix.server }} ${{ matrix.mc_version }} / Java ${{ matrix.java_version }}
+
+  # ── 1. Build the shaded plugin JAR once with JDK 25 ─────────────────────────
+  build:
+    name: Build plugin JAR
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - server: Paper
-            project: paper
-            mc_version: "1.21.11"
-            java_version: '21'
-          - server: Paper
-            project: paper
-            mc_version: "1.21.11"
-            java_version: '25'
-          - server: Folia
-            project: folia
-            mc_version: "1.21.11"
-            java_version: '21'
-          - server: Folia
-            project: folia
-            mc_version: "1.21.11"
-            java_version: '25'
-          - server: Spigot
-            project: spigot
-            mc_version: "1.21.11"
-            java_version: '21'
-          - server: Spigot
-            project: spigot
-            mc_version: "1.21.11"
-            java_version: '25'
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 25 (build)
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
           java-version: '25'
+          distribution: temurin
           cache: maven
 
       - name: Purge stale JitPack artifacts from Maven cache
         run: rm -rf ~/.m2/repository/com/github
 
-      - name: Build plugin JAR
+      - name: Build plugin (skip tests)
         run: mvn -B -ntp -DskipTests package
 
-      - name: Locate plugin JAR
-        id: jar
+      - name: Stage plugin JAR
         run: |
           JAR=$(find teams-api-plugin/target -maxdepth 1 \
             -name "teams-api-plugin-*.jar" ! -name "original-*" | head -1)
-          echo "path=$JAR" >> "$GITHUB_OUTPUT"
           echo "Located: $JAR"
+          cp "$JAR" plugin.jar
 
-      - name: Set up JDK ${{ matrix.java_version }} (server runtime)
-        id: server-jdk
+      - name: Upload plugin JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jar
+          path: plugin.jar
+          if-no-files-found: error
+
+  # ── 2. Smoke-test on each server / Java combination ──────────────────────────
+  smoke:
+    name: Smoke – ${{ matrix.server }} / Java ${{ matrix.java }}
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - server: paper
+            java: 21
+          - server: paper
+            java: 25
+          - server: folia
+            java: 21
+          - server: folia
+            java: 25
+          - server: spigot
+            java: 21
+          - server: spigot
+            java: 25
+
+    steps:
+      - name: Download plugin JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-jar
+
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
+          java-version: ${{ matrix.java }}
           distribution: temurin
-          java-version: ${{ matrix.java_version }}
 
-      # ── Paper / Folia ────────────────────────────────────────────────────────
+      # ── Paper ────────────────────────────────────────────────────────────────
 
-      - name: Download ${{ matrix.server }} ${{ matrix.mc_version }} JAR
-        if: matrix.project != 'spigot'
+      - name: Download Paper ${{ env.MC_VERSION }}
+        if: matrix.server == 'paper'
         run: |
           BUILD=$(curl -sf \
-            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds" \
+            "https://api.papermc.io/v2/projects/paper/versions/${{ env.MC_VERSION }}/builds" \
             | python3 -c "import sys,json; print(json.load(sys.stdin)['builds'][-1]['build'])")
-          JAR_NAME=$(curl -sf \
-            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds/${BUILD}" \
-            | python3 -c "import sys,json; print(json.load(sys.stdin)['downloads']['application']['name'])")
-          curl -sfL \
-            "https://api.papermc.io/v2/projects/${{ matrix.project }}/versions/${{ matrix.mc_version }}/builds/${BUILD}/downloads/${JAR_NAME}" \
-            -o server.jar
-          echo "Downloaded ${{ matrix.server }} ${{ matrix.mc_version }} build ${BUILD} (${JAR_NAME})"
+          curl -sfLo server.jar \
+            "https://api.papermc.io/v2/projects/paper/versions/${{ env.MC_VERSION }}/builds/${BUILD}/downloads/paper-${{ env.MC_VERSION }}-${BUILD}.jar"
+          echo "Paper build: $BUILD"
+
+      # ── Folia ────────────────────────────────────────────────────────────────
+
+      - name: Download Folia ${{ env.MC_VERSION }}
+        if: matrix.server == 'folia'
+        run: |
+          BUILD=$(curl -sf \
+            "https://api.papermc.io/v2/projects/folia/versions/${{ env.MC_VERSION }}/builds" \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['builds'][-1]['build'])")
+          curl -sfLo server.jar \
+            "https://api.papermc.io/v2/projects/folia/versions/${{ env.MC_VERSION }}/builds/${BUILD}/downloads/folia-${{ env.MC_VERSION }}-${BUILD}.jar"
+          echo "Folia build: $BUILD"
 
       # ── Spigot via BuildTools ────────────────────────────────────────────────
+      # BuildTools is strict about its build JVM: always run it with Java 21
+      # regardless of the matrix Java used to *run* the server.
 
-      - name: Cache Spigot ${{ matrix.mc_version }}
-        if: matrix.project == 'spigot'
-        id: cache-spigot
+      - name: Set up Java 21 for Spigot BuildTools
+        if: matrix.server == 'spigot'
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+
+      - name: Cache Spigot ${{ env.MC_VERSION }}
+        if: matrix.server == 'spigot'
+        id: spigot-cache
         uses: actions/cache@v4
         with:
-          path: ~/.spigot-cache
-          key: spigot-${{ matrix.mc_version }}-buildtools-v1
+          path: ~/spigot-jar
+          key: spigot-${{ env.MC_VERSION }}-buildtools-v1
 
       - name: Build Spigot via BuildTools
-        if: matrix.project == 'spigot' && steps.cache-spigot.outputs.cache-hit != 'true'
+        if: matrix.server == 'spigot' && steps.spigot-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 25
         run: |
           git config --global user.email "ci@example.com"
           git config --global user.name "GitHub Actions CI"
-          mkdir -p ~/.spigot-cache
-          cd ~/.spigot-cache
-          curl -sfL \
-            https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar \
-            -o BuildTools.jar
-          java -jar BuildTools.jar --rev ${{ matrix.mc_version }} --compile SPIGOT 2>&1
+          mkdir -p ~/spigot-jar buildtools
+          cd buildtools
+          curl -sfLo BuildTools.jar \
+            "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar"
+          "$JAVA_HOME_21_X64/bin/java" -jar BuildTools.jar \
+            --rev "${{ env.MC_VERSION }}" --compile SPIGOT --nogui
+          cp "spigot-${{ env.MC_VERSION }}.jar" "$HOME/spigot-jar/"
 
-      - name: Copy Spigot JAR
-        if: matrix.project == 'spigot'
-        run: cp ~/.spigot-cache/spigot-${{ matrix.mc_version }}.jar server.jar
+      # Restore the matrix Java so the server runs on the intended JVM.
+      - name: Restore JDK ${{ matrix.java }} (server runtime)
+        if: matrix.server == 'spigot'
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+
+      - name: Use Spigot JAR
+        if: matrix.server == 'spigot'
+        run: cp "$HOME/spigot-jar/spigot-${{ env.MC_VERSION }}.jar" server.jar
 
       # ── Prepare server directory ─────────────────────────────────────────────
 
@@ -125,7 +160,7 @@ jobs:
         run: |
           mkdir -p server/plugins
           cp server.jar server/server.jar
-          cp "${{ steps.jar.outputs.path }}" server/plugins/TeamsAPI.jar
+          cp plugin.jar server/plugins/TeamsAPI.jar
           echo "eula=true" > server/eula.txt
           {
             echo "online-mode=false"
@@ -135,83 +170,85 @@ jobs:
             echo "simulation-distance=2"
           } > server/server.properties
 
-      # ── Start server ─────────────────────────────────────────────────────────
+      # ── Smoke test ───────────────────────────────────────────────────────────
 
-      - name: Start server and wait for Done
-        env:
-          JAVA_CMD: ${{ steps.server-jdk.outputs.java-home }}/bin/java
+      - name: Run smoke test
+        timeout-minutes: 5
         run: |
           cd server
-          "${JAVA_CMD}" -Xmx512M -Xms512M -jar server.jar --nogui > server.log 2>&1 &
+          java -Xmx512M -Xms512M -jar server.jar --nogui > server.log 2>&1 &
           SERVER_PID=$!
           echo "Server PID: ${SERVER_PID}"
 
-          # Poll every 5 s, up to 3 minutes
-          for i in $(seq 1 36); do
-            if grep -q "Done (" server.log 2>/dev/null; then
-              echo "Server reached Done state after $((i * 5))s"
+          FAIL_PAT="NoSuchMethodError|NoSuchFieldError|Error enabling plugin TeamsAPI|Error occurred while enabling TeamsAPI"
+          RESULT=timeout
+
+          for i in $(seq 1 120); do
+            sleep 1
+
+            # Hard failure — API incompatibility or onEnable exception
+            if grep -qE "$FAIL_PAT" server.log 2>/dev/null; then
+              RESULT=fail
               break
             fi
-            if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
-              echo "::error::Server process exited before reaching Done state"
-              cat server.log
-              exit 1
+
+            # Server fully started — all plugins enabled without errors
+            if grep -qE "Done \([0-9.]" server.log 2>/dev/null; then
+              if grep -qE "$FAIL_PAT" server.log 2>/dev/null; then
+                RESULT=fail
+              else
+                RESULT=pass
+              fi
+              break
             fi
-            sleep 5
+
+            # Enabling logged — wait 5 s for any delayed crash before declaring pass
+            if grep -q "Enabling TeamsAPI" server.log 2>/dev/null; then
+              sleep 5
+              if grep -qE "$FAIL_PAT" server.log 2>/dev/null; then
+                RESULT=fail
+              else
+                RESULT=pass
+              fi
+              break
+            fi
+
+            if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+              echo "Server process exited before reaching Done state."
+              RESULT=fail
+              break
+            fi
           done
 
-          if ! grep -q "Done (" server.log; then
-            echo "::error::Server did not reach Done state within 180s"
-            kill "${SERVER_PID}" 2>/dev/null || true
-            cat server.log
-            exit 1
-          fi
-
-          # Graceful stop
-          kill "${SERVER_PID}"
+          # SIGKILL guarantees the JVM exits immediately
+          kill -9 "${SERVER_PID}" 2>/dev/null || true
           wait "${SERVER_PID}" 2>/dev/null || true
-          echo "Server stopped"
 
-      # ── Assertions ───────────────────────────────────────────────────────────
+          echo ""
+          echo "=== Error context in server.log ==="
+          grep -n -B1 -A25 -E \
+            "Error occurred while enabling|Error enabling plugin|NoSuchMethodError|NoSuchFieldError" \
+            server.log | head -80 || true
+          echo ""
+          echo "=== Last 100 lines of server.log ==="
+          tail -100 server.log
+          echo "====================================="
+          echo ""
 
-      - name: Assert TeamsAPI loaded cleanly
-        run: |
-          LOG=server/server.log
-
-          echo "=== TeamsAPI log lines ==="
-          grep -i "teamsapi" "${LOG}" || true
-          echo "=========================="
-
-          # Plugin must have printed its enabled banner
-          if ! grep -q "TeamsAPI v.*enabled\." "${LOG}"; then
-            echo "::error::TeamsAPI enabled banner not found in server log"
-            cat "${LOG}"
+          if [ "$RESULT" = "pass" ]; then
+            echo "PASS: TeamsAPI enabled on ${{ matrix.server }} / Java ${{ matrix.java }}"
+          elif [ "$RESULT" = "fail" ]; then
+            echo "FAIL: Plugin threw an error during startup"
+            exit 1
+          else
+            echo "FAIL: Timed out — TeamsAPI never appeared in server.log within 120 s"
             exit 1
           fi
-
-          # No SEVERE or ERROR lines from TeamsAPI's own logger.
-          # Use the [TeamsAPI] prefix to avoid false positives from the server's
-          # bytecode remapper (Commodore) which may log errors mentioning the
-          # plugin name when processing the MRJAR on newer JVMs.
-          if grep -E 'SEVERE|ERROR' "${LOG}" | grep -q '\[TeamsAPI\]'; then
-            echo "::error::TeamsAPI produced a SEVERE or ERROR log entry"
-            cat "${LOG}"
-            exit 1
-          fi
-
-          # No exception stack traces from within TeamsAPI's own code
-          if grep -iE 'exception|caused by' "${LOG}" | grep -q '\[TeamsAPI\]'; then
-            echo "::error::Exception detected in TeamsAPI context"
-            cat "${LOG}"
-            exit 1
-          fi
-
-          echo "OK – TeamsAPI loaded cleanly on ${{ matrix.server }} ${{ matrix.mc_version }} / Java ${{ matrix.java_version }}"
 
       - name: Upload server log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: server-log-${{ matrix.server }}-${{ matrix.mc_version }}-java${{ matrix.java_version }}
+          name: server-log-${{ matrix.server }}-java${{ matrix.java }}
           path: server/server.log
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TeamsRelationService.getTeamsInRelation(teamId, relation)` — default convenience
   method that returns all team UUIDs toward which `teamId` has declared the given
   relation. Providers may override for a more efficient implementation.
+- `TeamsRelationService.getRelationColor(relation)` — default method that returns
+  the display color for a relation as a `#RRGGBB` hex string. Providers may override
+  to supply server-configured colors; falls back to `TeamRelation.getDefaultHexColor()`.
 - `TeamsAPI.API_VERSION` bumped to `1.6.1`.
 
 ## [1.6.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.1]
+
+### Added
+
+- `TeamRelation.getDisplayName()` — returns a human-friendly relation name
+  ("Ally", "Truce", "Neutral", "Enemy").
+- `TeamRelation.getLegacyColorCode()` — returns the legacy Minecraft color code
+  character (`'a'` green, `'6'` gold, `'7'` gray, `'c'` red) for use in chat
+  formatting: `"§" + relation.getLegacyColorCode()`.
+- `TeamRelation.getDefaultHexColor()` — returns a `#RRGGBB` hex string suitable
+  for Adventure / MiniMessage consumers (`#55FF55`, `#FFAA00`, `#AAAAAA`, `#FF5555`).
+- `TeamsRelationService.getTeamsInRelation(teamId, relation)` — default convenience
+  method that returns all team UUIDs toward which `teamId` has declared the given
+  relation. Providers may override for a more efficient implementation.
+- `TeamsAPI.API_VERSION` bumped to `1.6.1`.
+
 ## [1.6.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.1'
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -217,6 +217,7 @@ responded. Whether a relation requires mutual agreement for benefits is provider
 | `clearRelations(teamId)` | `boolean` | Removes all relations declared by or toward the team (e.g. on disband). Returns `false` if the team had no relations. |
 | `areAllies(teamAId, teamBId)` | `boolean` | Default: returns `true` when both teams have declared `ALLY` toward each other. |
 | `areEnemies(teamAId, teamBId)` | `boolean` | Default: returns `true` when either team has declared `ENEMY` toward the other. |
+| `getTeamsInRelation(teamId, relation)` | `Collection<UUID>` | Default: returns all team UUIDs toward which `teamId` has declared the given relation. Equivalent to filtering `getRelations(teamId)` by value. Providers may override for efficiency. |
 
 ## `Team` (interface)
 
@@ -277,20 +278,23 @@ methods.
 Represents the relationship one team has declared toward another. Ordinal ordering
 (lowest hostility → highest): `ALLY < TRUCE < NEUTRAL < ENEMY`.
 
-| Constant | Description |
-|----------|-------------|
-| `ALLY`    | Formal alliance — mutual benefits apply. |
-| `TRUCE`   | Agreed ceasefire — no active hostility. |
-| `NEUTRAL` | No formal relation (default when none is set). |
-| `ENEMY`   | Actively hostile. |
+| Constant | Display name | Legacy color | Hex color | Description |
+|----------|-------------|--------------|-----------|-------------|
+| `ALLY`    | "Ally"    | `§a` (green) | `#55FF55` | Formal alliance — mutual benefits apply. |
+| `TRUCE`   | "Truce"   | `§6` (gold)  | `#FFAA00` | Agreed ceasefire — no active hostility. |
+| `NEUTRAL` | "Neutral" | `§7` (gray)  | `#AAAAAA` | No formal relation (default when none is set). |
+| `ENEMY`   | "Enemy"   | `§c` (red)   | `#FF5555` | Actively hostile. |
 
 Helper methods:
 
-| Method | Description |
-|--------|-------------|
-| `isFriendly()` | Returns `true` for `ALLY` and `TRUCE`. |
-| `isHostile()` | Returns `true` for `ENEMY`. |
-| `isMoreHostileThan(other)` | Returns `true` if this relation has a higher hostility level than `other`. |
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getDisplayName()` | `String` | Human-friendly name ("Ally", "Truce", etc.). |
+| `getLegacyColorCode()` | `char` | Legacy color code character; prepend `§` to build the full code: `"§" + rel.getLegacyColorCode()`. |
+| `getDefaultHexColor()` | `String` | Default `#RRGGBB` hex string for Adventure / MiniMessage consumers. |
+| `isFriendly()` | `boolean` | Returns `true` for `ALLY` and `TRUCE`. |
+| `isHostile()` | `boolean` | Returns `true` for `ENEMY`. |
+| `isMoreHostileThan(other)` | `boolean` | Returns `true` if this relation has a higher hostility level than `other`. |
 
 ## `TeamRole` (enum)
 
@@ -352,6 +356,16 @@ All concrete events implement `Cancellable`.
 | `TeamRelationChangeEvent` | Yes | `getTeam()` (source), `getTargetTeam()`, `getInitiatorUUID()`, `getOldRelation()`, `getNewRelation()`, `setNewRelation(relation)` |
 
 ## Migration notes
+
+### 1.6.1
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- `TeamRelation` now carries presentation metadata: `getDisplayName()`,
+  `getLegacyColorCode()`, and `getDefaultHexColor()`.
+- New default method `TeamsRelationService.getTeamsInRelation(teamId, relation)`:
+  returns all team UUIDs toward which `teamId` has declared the given relation.
+- `TeamsAPI.API_VERSION` bumped from `1.6.0` to `1.6.1`.
 
 ### 1.6.0
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -218,6 +218,7 @@ responded. Whether a relation requires mutual agreement for benefits is provider
 | `areAllies(teamAId, teamBId)` | `boolean` | Default: returns `true` when both teams have declared `ALLY` toward each other. |
 | `areEnemies(teamAId, teamBId)` | `boolean` | Default: returns `true` when either team has declared `ENEMY` toward the other. |
 | `getTeamsInRelation(teamId, relation)` | `Collection<UUID>` | Default: returns all team UUIDs toward which `teamId` has declared the given relation. Equivalent to filtering `getRelations(teamId)` by value. Providers may override for efficiency. |
+| `getRelationColor(relation)` | `String` | Default: returns `relation.getDefaultHexColor()`. Providers may override to supply server-configured colors. Consumers should prefer this over reading the enum directly to honour provider customisation. |
 
 ## `Team` (interface)
 
@@ -365,6 +366,11 @@ Non-breaking addition. No changes required for existing providers or consumers.
   `getLegacyColorCode()`, and `getDefaultHexColor()`.
 - New default method `TeamsRelationService.getTeamsInRelation(teamId, relation)`:
   returns all team UUIDs toward which `teamId` has declared the given relation.
+- New default method `TeamsRelationService.getRelationColor(relation)`: returns
+  the display color for a relation as a `#RRGGBB` hex string. Providers may
+  override to supply server-configured colors; falls back to
+  `TeamRelation.getDefaultHexColor()`. Chat plugins should call this instead of
+  reading the enum directly.
 - `TeamsAPI.API_VERSION` bumped from `1.6.0` to `1.6.1`.
 
 ### 1.6.0

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -251,6 +251,7 @@ TeamsAPI.registerRelationProvider(this, relationService);
 | `areAllies(teamAId, teamBId)` | `boolean` | Returns `true` when both teams have declared `ALLY` toward each other. |
 | `areEnemies(teamAId, teamBId)` | `boolean` | Returns `true` when either team has declared `ENEMY` toward the other. |
 | `getTeamsInRelation(teamId, relation)` | `Collection<UUID>` | Returns all team UUIDs toward which `teamId` has declared the given relation. Filters `getRelations(teamId)` by value; providers may override for efficiency. |
+| `getRelationColor(relation)` | `String` | `#RRGGBB` hex color for the relation. Default returns `relation.getDefaultHexColor()`; providers may override to supply server-configured colors. |
 
 `TeamRelation` values with display name, legacy color code, and hex color:
 

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -72,7 +72,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -84,7 +84,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.1'
 }
 ```
 
@@ -250,8 +250,16 @@ TeamsAPI.registerRelationProvider(this, relationService);
 | `clearRelations(teamId)` | `boolean` | Removes all relations declared by or toward the team (use on disband). |
 | `areAllies(teamAId, teamBId)` | `boolean` | Returns `true` when both teams have declared `ALLY` toward each other. |
 | `areEnemies(teamAId, teamBId)` | `boolean` | Returns `true` when either team has declared `ENEMY` toward the other. |
+| `getTeamsInRelation(teamId, relation)` | `Collection<UUID>` | Returns all team UUIDs toward which `teamId` has declared the given relation. Filters `getRelations(teamId)` by value; providers may override for efficiency. |
 
-`TeamRelation` values (lowest → highest hostility): `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`.
+`TeamRelation` values with display name, legacy color code, and hex color:
+
+| Constant | Display name | Legacy color | Hex color |
+|----------|-------------|--------------|-----------|
+| `ALLY`    | "Ally"    | `§a` (green) | `#55FF55` |
+| `TRUCE`   | "Truce"   | `§6` (gold)  | `#FFAA00` |
+| `NEUTRAL` | "Neutral" | `§7` (gray)  | `#AAAAAA` |
+| `ENEMY`   | "Enemy"   | `§c` (red)   | `#FF5555` |
 
 Consumers check availability with `TeamsAPI.isRelationAvailable()` before calling `TeamsAPI.getRelationService()`.
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -76,7 +76,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -88,7 +88,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.6.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.6.1'
 }
 [/CODE]
 [/SPOILER]
@@ -224,9 +224,17 @@ public void onDisable() {
 [*][COLOR=#6cb4ff]clearRelations(teamId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Removes all relations declared by or toward the team (use on disband).
 [*][COLOR=#6cb4ff]areAllies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when both teams have declared [COLOR=#ffd700]ALLY[/COLOR] toward each other.
 [*][COLOR=#6cb4ff]areEnemies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when either team has declared [COLOR=#ffd700]ENEMY[/COLOR] toward the other.
+[*][COLOR=#6cb4ff]getTeamsInRelation(teamId, relation)[/COLOR] -> [COLOR=#ffd700]Collection<UUID>[/COLOR] -- All team UUIDs toward which [COLOR=#ffd700]teamId[/COLOR] has declared the given relation; providers may override for efficiency.
 [/LIST]
 
-[COLOR=#aaaaaa]TeamRelation values (lowest → highest hostility): [COLOR=#ffd700]ALLY[/COLOR], [COLOR=#ffd700]TRUCE[/COLOR], [COLOR=#ffd700]NEUTRAL[/COLOR], [COLOR=#ffd700]ENEMY[/COLOR].[/COLOR]
+[COLOR=#aaaaaa]TeamRelation display names, legacy color codes, and hex colors:[/COLOR]
+
+[LIST]
+[*][COLOR=#55FF55][COLOR=#ffd700]ALLY[/COLOR][/COLOR] -- display: "Ally", legacy: [COLOR=#6cb4ff]§a[/COLOR] (green), hex: [COLOR=#55FF55]#55FF55[/COLOR]
+[*][COLOR=#FFAA00][COLOR=#ffd700]TRUCE[/COLOR][/COLOR] -- display: "Truce", legacy: [COLOR=#6cb4ff]§6[/COLOR] (gold), hex: [COLOR=#FFAA00]#FFAA00[/COLOR]
+[*][COLOR=#AAAAAA][COLOR=#ffd700]NEUTRAL[/COLOR][/COLOR] -- display: "Neutral", legacy: [COLOR=#6cb4ff]§7[/COLOR] (gray), hex: [COLOR=#AAAAAA]#AAAAAA[/COLOR]
+[*][COLOR=#FF5555][COLOR=#ffd700]ENEMY[/COLOR][/COLOR] -- display: "Enemy", legacy: [COLOR=#6cb4ff]§c[/COLOR] (red), hex: [COLOR=#FF5555]#FF5555[/COLOR]
+[/LIST]
 
 [SIZE=4][B]Custom subcommands[/B][/SIZE]
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -225,6 +225,7 @@ public void onDisable() {
 [*][COLOR=#6cb4ff]areAllies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when both teams have declared [COLOR=#ffd700]ALLY[/COLOR] toward each other.
 [*][COLOR=#6cb4ff]areEnemies(teamAId, teamBId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- [COLOR=#ffd700]true[/COLOR] when either team has declared [COLOR=#ffd700]ENEMY[/COLOR] toward the other.
 [*][COLOR=#6cb4ff]getTeamsInRelation(teamId, relation)[/COLOR] -> [COLOR=#ffd700]Collection<UUID>[/COLOR] -- All team UUIDs toward which [COLOR=#ffd700]teamId[/COLOR] has declared the given relation; providers may override for efficiency.
+[*][COLOR=#6cb4ff]getRelationColor(relation)[/COLOR] -> [COLOR=#ffd700]String[/COLOR] -- [COLOR=#ffd700]#RRGGBB[/COLOR] hex color for the relation. Default returns [COLOR=#6cb4ff]TeamRelation.getDefaultHexColor()[/COLOR]; providers override to supply server-configured colors.
 [/LIST]
 
 [COLOR=#aaaaaa]TeamRelation display names, legacy color codes, and hex colors:[/COLOR]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/src/main/resources/plugin.yml
+++ b/teams-api-plugin/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ description: >
   depend on them. Install this plugin alongside any TeamsAPI-compatible team plugin.
 author: ez-plugins
 website: https://github.com/ez-plugins/teams-api
+softdepend: [Vault]
 
 commands:
   teamsapi:

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -52,7 +52,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.6.0";
+    public static final String API_VERSION = "1.6.1";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
@@ -2,8 +2,10 @@ package com.skyblockexp.teamsapi.api;
 
 import com.skyblockexp.teamsapi.model.TeamRelation;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Optional extension service for inter-team relation management.
@@ -134,5 +136,37 @@ public interface TeamsRelationService {
     default boolean areEnemies(final UUID teamAId, final UUID teamBId) {
         return getRelation(teamAId, teamBId) == TeamRelation.ENEMY
             || getRelation(teamBId, teamAId) == TeamRelation.ENEMY;
+    }
+
+    /**
+     * Returns the UUIDs of all teams toward which the given team has declared the
+     * specified relation.
+     *
+     * <p>This is a convenience shorthand for filtering {@link #getRelations(UUID)}.
+     * Providers may override this method with a more efficient implementation (e.g.
+     * an indexed database query).</p>
+     *
+     * <p>Example — collect all players in teams that are allied to {@code myTeamId}:</p>
+     * <pre>{@code
+     * Collection<UUID> alliedTeamIds =
+     *     relService.getTeamsInRelation(myTeamId, TeamRelation.ALLY);
+     *
+     * List<UUID> alliedPlayers = alliedTeamIds.stream()
+     *     .flatMap(id -> teamsService.getTeam(id).stream())
+     *     .flatMap(t  -> t.getMemberUUIDs().stream())
+     *     .collect(Collectors.toList());
+     * }</pre>
+     *
+     * @param teamId   the UUID of the team whose outgoing relations are queried;
+     *                 must not be {@code null}
+     * @param relation the {@link TeamRelation} to filter by; must not be {@code null}
+     * @return an unmodifiable collection of team UUIDs that have been assigned the
+     *         given relation by {@code teamId}; never {@code null}, empty if none exist
+     */
+    default Collection<UUID> getTeamsInRelation(final UUID teamId, final TeamRelation relation) {
+        return getRelations(teamId).entrySet().stream()
+            .filter(e -> e.getValue() == relation)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
@@ -169,4 +169,27 @@ public interface TeamsRelationService {
             .map(Map.Entry::getKey)
             .collect(Collectors.toUnmodifiableList());
     }
+
+    /**
+     * Returns the display color for the given relation on this server as a
+     * {@code #RRGGBB} hex string.
+     *
+     * <p>Providers may override this method to supply server-configured colors.
+     * The default implementation delegates to
+     * {@link TeamRelation#getDefaultHexColor()}, so consumers always obtain a
+     * valid color even when the provider has not overridden it.</p>
+     *
+     * <p>Priority for chat plugins:</p>
+     * <ol>
+     *   <li>Consumer's own per-relation config (highest)</li>
+     *   <li>This method — provider-supplied color</li>
+     *   <li>{@link TeamRelation#getDefaultHexColor()} — API default (lowest)</li>
+     * </ol>
+     *
+     * @param relation the relation type; must not be {@code null}
+     * @return a {@code #RRGGBB} hex color string; never {@code null}
+     */
+    default String getRelationColor(final TeamRelation relation) {
+        return relation.getDefaultHexColor();
+    }
 }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
@@ -13,23 +13,126 @@ package com.skyblockexp.teamsapi.model;
  * <p>Relations may be directional or symmetric depending on the provider.
  * Consumers should use {@link com.skyblockexp.teamsapi.api.TeamsRelationService}
  * to query and manage relations.</p>
+ *
+ * <p>Each constant carries a human-friendly display name, a legacy Minecraft color
+ * code character (for use with the {@code §} prefix in chat), and a default hex
+ * color string for Adventure / MiniMessage consumers.</p>
  */
 public enum TeamRelation {
 
     /** The two teams are formal allies — mutual benefits apply. */
-    ALLY,
+    ALLY("Ally", 'a', "#55FF55"),
 
     /** The two teams have agreed to a temporary truce — no active hostility. */
-    TRUCE,
+    TRUCE("Truce", '6', "#FFAA00"),
 
     /**
      * No formal relation has been set; neither friendly nor hostile.
      * This is the default state returned when no explicit relation exists.
      */
-    NEUTRAL,
+    NEUTRAL("Neutral", '7', "#AAAAAA"),
 
     /** The two teams are actively hostile toward each other. */
-    ENEMY;
+    ENEMY("Enemy", 'c', "#FF5555");
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    /** Human-friendly display name (e.g. "Ally"). */
+    private final String displayName;
+
+    /**
+     * Legacy Minecraft color code character.
+     *
+     * <p>Build the full color code by prepending {@code §}:
+     * {@code "§" + getLegacyColorCode()}</p>
+     */
+    private final char legacyColorCode;
+
+    /**
+     * Default hex color string in {@code #RRGGBB} format, suitable for use with
+     * Paper's Adventure API or MiniMessage:
+     * {@code "<color:" + getDefaultHexColor() + ">text</color>"}
+     */
+    private final String defaultHexColor;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@link TeamRelation} constant with the given presentation attributes.
+     *
+     * @param displayName     the human-friendly name; must not be {@code null}
+     * @param legacyColorCode the legacy Minecraft color code character (e.g. {@code 'a'} for green)
+     * @param defaultHexColor the default hex color string in {@code #RRGGBB} format
+     */
+    TeamRelation(final String displayName, final char legacyColorCode,
+            final String defaultHexColor) {
+        this.displayName = displayName;
+        this.legacyColorCode = legacyColorCode;
+        this.defaultHexColor = defaultHexColor;
+    }
+
+    // -------------------------------------------------------------------------
+    // Presentation helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the human-friendly display name of this relation.
+     *
+     * <p>Examples: {@code "Ally"}, {@code "Truce"}, {@code "Neutral"}, {@code "Enemy"}.</p>
+     *
+     * @return the display name; never {@code null}
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Returns the legacy Minecraft color code character for this relation.
+     *
+     * <p>Build the full legacy color code by prepending the section sign:</p>
+     * <pre>{@code String colorCode = "§" + relation.getLegacyColorCode();}</pre>
+     *
+     * <p>Default color assignments:</p>
+     * <ul>
+     *   <li>{@link #ALLY} → {@code 'a'} (green)</li>
+     *   <li>{@link #TRUCE} → {@code '6'} (gold)</li>
+     *   <li>{@link #NEUTRAL} → {@code '7'} (gray)</li>
+     *   <li>{@link #ENEMY} → {@code 'c'} (red)</li>
+     * </ul>
+     *
+     * @return the legacy color code character
+     */
+    public char getLegacyColorCode() {
+        return legacyColorCode;
+    }
+
+    /**
+     * Returns the default hex color string for this relation in {@code #RRGGBB} format.
+     *
+     * <p>This value is suitable for use with Paper's Adventure API or MiniMessage:</p>
+     * <pre>{@code
+     * Component name = MiniMessage.miniMessage()
+     *     .deserialize("<color:" + relation.getDefaultHexColor() + ">"
+     *         + relation.getDisplayName() + "</color>");
+     * }</pre>
+     *
+     * <p>Default color assignments:</p>
+     * <ul>
+     *   <li>{@link #ALLY} → {@code "#55FF55"} (bright green)</li>
+     *   <li>{@link #TRUCE} → {@code "#FFAA00"} (gold)</li>
+     *   <li>{@link #NEUTRAL} → {@code "#AAAAAA"} (gray)</li>
+     *   <li>{@link #ENEMY} → {@code "#FF5555"} (red)</li>
+     * </ul>
+     *
+     * @return the hex color string; never {@code null}
+     */
+    public String getDefaultHexColor() {
+        return defaultHexColor;
+    }
 
     // -------------------------------------------------------------------------
     // Convenience helpers

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -284,5 +285,42 @@ class TeamsAPIRelationTest {
         final Collection<UUID> allies = service.getTeamsInRelation(myTeam, TeamRelation.ALLY);
 
         assertTrue(allies.isEmpty());
+    }
+
+    // TeamsRelationService — getRelationColor default method
+
+    /**
+     * getRelationColor_defaultImpl_returnsEnumHexColor verifies that the default
+     * implementation of {@link TeamsRelationService#getRelationColor(TeamRelation)}
+     * returns the same value as {@link TeamRelation#getDefaultHexColor()} for every
+     * relation constant.
+     */
+    @Test
+    void getRelationColor_defaultImpl_returnsEnumHexColor() {
+        final TeamsRelationService service = mock(TeamsRelationService.class);
+        when(service.getRelationColor(any(TeamRelation.class))).thenCallRealMethod();
+
+        for (final TeamRelation relation : TeamRelation.values()) {
+            assertEquals(
+                relation.getDefaultHexColor(),
+                service.getRelationColor(relation),
+                "Default color mismatch for " + relation
+            );
+        }
+    }
+
+    /**
+     * getRelationColor_providerOverride_returnsCustomColor verifies that a provider
+     * can override {@link TeamsRelationService#getRelationColor(TeamRelation)} to
+     * return a server-specific color, taking precedence over the enum default.
+     */
+    @Test
+    void getRelationColor_providerOverride_returnsCustomColor() {
+        final TeamsRelationService service = mock(TeamsRelationService.class);
+        when(service.getRelationColor(TeamRelation.ALLY)).thenReturn("#0000FF");
+        when(service.getRelationColor(TeamRelation.ENEMY)).thenCallRealMethod();
+
+        assertEquals("#0000FF", service.getRelationColor(TeamRelation.ALLY));
+        assertEquals(TeamRelation.ENEMY.getDefaultHexColor(), service.getRelationColor(TeamRelation.ENEMY));
     }
 }

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
@@ -5,6 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.skyblockexp.teamsapi.model.TeamRelation;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -171,5 +178,111 @@ class TeamsAPIRelationTest {
 
         assertTrue(TeamsAPI.isRelationAvailable());
         assertFalse(TeamsAPI.isAvailable());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamRelation enum — display name
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamRelation_getDisplayName_returnsCorrectName verifies that every
+     * {@link TeamRelation} constant returns the expected human-friendly display name.
+     */
+    @Test
+    void teamRelation_getDisplayName_returnsCorrectName() {
+        assertEquals("Ally",    TeamRelation.ALLY.getDisplayName());
+        assertEquals("Truce",   TeamRelation.TRUCE.getDisplayName());
+        assertEquals("Neutral", TeamRelation.NEUTRAL.getDisplayName());
+        assertEquals("Enemy",   TeamRelation.ENEMY.getDisplayName());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamRelation enum — legacy color code
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamRelation_getLegacyColorCode_returnsCorrectCode verifies that every
+     * {@link TeamRelation} constant returns the expected legacy Minecraft color code
+     * character.
+     */
+    @Test
+    void teamRelation_getLegacyColorCode_returnsCorrectCode() {
+        assertEquals('a', TeamRelation.ALLY.getLegacyColorCode());
+        assertEquals('6', TeamRelation.TRUCE.getLegacyColorCode());
+        assertEquals('7', TeamRelation.NEUTRAL.getLegacyColorCode());
+        assertEquals('c', TeamRelation.ENEMY.getLegacyColorCode());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamRelation enum — default hex color
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamRelation_getDefaultHexColor_returnsCorrectHex verifies that every
+     * {@link TeamRelation} constant returns the expected default hex color string.
+     */
+    @Test
+    void teamRelation_getDefaultHexColor_returnsCorrectHex() {
+        assertEquals("#55FF55", TeamRelation.ALLY.getDefaultHexColor());
+        assertEquals("#FFAA00", TeamRelation.TRUCE.getDefaultHexColor());
+        assertEquals("#AAAAAA", TeamRelation.NEUTRAL.getDefaultHexColor());
+        assertEquals("#FF5555", TeamRelation.ENEMY.getDefaultHexColor());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamsRelationService — getTeamsInRelation default method
+    // -------------------------------------------------------------------------
+
+    /**
+     * getTeamsInRelation_returnsOnlyTeamsMatchingRelation verifies that
+     * {@link TeamsRelationService#getTeamsInRelation(UUID, TeamRelation)} returns
+     * only the team UUIDs for which the given team has declared the specified relation,
+     * excluding teams with other relations.
+     */
+    @Test
+    void getTeamsInRelation_returnsOnlyTeamsMatchingRelation() {
+        final UUID myTeam    = UUID.randomUUID();
+        final UUID allyTeam  = UUID.randomUUID();
+        final UUID enemyTeam = UUID.randomUUID();
+        final UUID truceTeam = UUID.randomUUID();
+
+        final TeamsRelationService service = mock(TeamsRelationService.class);
+        when(service.getRelations(myTeam)).thenReturn(Map.of(
+            allyTeam,  TeamRelation.ALLY,
+            enemyTeam, TeamRelation.ENEMY,
+            truceTeam, TeamRelation.TRUCE
+        ));
+        // Wire through the default implementation
+        when(service.getTeamsInRelation(myTeam, TeamRelation.ALLY))
+            .thenCallRealMethod();
+
+        final Collection<UUID> allies = service.getTeamsInRelation(myTeam, TeamRelation.ALLY);
+
+        assertEquals(1, allies.size());
+        assertTrue(allies.contains(allyTeam));
+        assertFalse(allies.contains(enemyTeam));
+        assertFalse(allies.contains(truceTeam));
+    }
+
+    /**
+     * getTeamsInRelation_returnsEmpty_whenNoMatchingRelation verifies that
+     * {@link TeamsRelationService#getTeamsInRelation(UUID, TeamRelation)} returns an
+     * empty collection when the team has no relations matching the requested type.
+     */
+    @Test
+    void getTeamsInRelation_returnsEmpty_whenNoMatchingRelation() {
+        final UUID myTeam    = UUID.randomUUID();
+        final UUID enemyTeam = UUID.randomUUID();
+
+        final TeamsRelationService service = mock(TeamsRelationService.class);
+        when(service.getRelations(myTeam)).thenReturn(Map.of(
+            enemyTeam, TeamRelation.ENEMY
+        ));
+        when(service.getTeamsInRelation(myTeam, TeamRelation.ALLY))
+            .thenCallRealMethod();
+
+        final Collection<UUID> allies = service.getTeamsInRelation(myTeam, TeamRelation.ALLY);
+
+        assertTrue(allies.isEmpty());
     }
 }


### PR DESCRIPTION
### Added

- `TeamRelation.getDisplayName()` — returns a human-friendly relation name
  ("Ally", "Truce", "Neutral", "Enemy").
- `TeamRelation.getLegacyColorCode()` — returns the legacy Minecraft color code
  character (`'a'` green, `'6'` gold, `'7'` gray, `'c'` red) for use in chat
  formatting: `"§" + relation.getLegacyColorCode()`.
- `TeamRelation.getDefaultHexColor()` — returns a `#RRGGBB` hex string suitable
  for Adventure / MiniMessage consumers (`#55FF55`, `#FFAA00`, `#AAAAAA`, `#FF5555`).
- `TeamsRelationService.getTeamsInRelation(teamId, relation)` — default convenience
  method that returns all team UUIDs toward which `teamId` has declared the given
  relation. Providers may override for a more efficient implementation.
- `TeamsRelationService.getRelationColor(relation)` — default method that returns
  the display color for a relation as a `#RRGGBB` hex string. Providers may override
  to supply server-configured colors; falls back to `TeamRelation.getDefaultHexColor()`.
- `TeamsAPI.API_VERSION` bumped to `1.6.1`.