### PR TITLE
feat: added power history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.8.0]
+
+### Added
+
+- `TeamsPowerHistoryService` optional extension interface for reading and
+  managing power-history entries through TeamsAPI.
+- New power-history model types:
+  `TeamPowerHistoryEntry` and `TeamPowerHistoryType`
+  (`GAIN`, `LOSS`, `ADJUSTMENT`).
+- New `TeamsAPI` power-history facade methods:
+  `getPowerHistoryService()`, `isPowerHistoryAvailable()`,
+  `registerPowerHistoryProvider(plugin, service)`,
+  `registerPowerHistoryProvider(plugin, service, priority)`,
+  `unregisterPowerHistoryProvider(service)`.
+- New tests:
+  `TeamsAPIPowerHistoryTest` (service registration/availability/null-safety)
+  and `TeamPowerHistoryTypeTest` (enum contract coverage).
+- `TeamsAPI.API_VERSION` bumped to `1.8.0`.
+
 ## [1.7.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.7.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.8.0'
 }
 ```
 
@@ -198,6 +198,35 @@ if (TeamsAPI.isPowerAvailable()) {
     double current = power.getTeamPower(teamId);
     double max = power.getTeamMaxPower(teamId);
     player.sendMessage("Team power: " + current + " / " + max);
+}
+```
+
+### Power history service (optional)
+
+If the active team plugin exposes power history, a `TeamsPowerHistoryService`
+is available:
+
+```java
+if (TeamsAPI.isPowerHistoryAvailable()) {
+    TeamsPowerHistoryService history = TeamsAPI.getPowerHistoryService();
+    Collection<TeamPowerHistoryEntry> recent =
+        history.getPlayerPowerHistory(player.getUniqueId(), 25);
+}
+```
+
+Providers that expose power history register the service alongside `TeamsService`:
+
+```java
+@Override
+public void onEnable() {
+    TeamsAPI.registerProvider(this, teamsService);
+    TeamsAPI.registerPowerHistoryProvider(this, powerHistoryService);
+}
+
+@Override
+public void onDisable() {
+    TeamsAPI.unregisterProvider(teamsService);
+    TeamsAPI.unregisterPowerHistoryProvider(powerHistoryService);
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,16 @@ Entry point for all API interactions. All methods are static.
 | `registerPowerProvider(plugin, service, priority)` | Registers a power provider at the given priority. |
 | `unregisterPowerProvider(service)` | Unregisters a power provider from Bukkit's ServicesManager. |
 
+**Power history service**
+
+| Method | Description |
+|--------|-------------|
+| `getPowerHistoryService()` | Returns the active `TeamsPowerHistoryService`, or `null` if none is registered. |
+| `isPowerHistoryAvailable()` | Returns `true` when a power-history provider is registered. |
+| `registerPowerHistoryProvider(plugin, service)` | Registers a power-history provider at `ServicePriority.Normal`. |
+| `registerPowerHistoryProvider(plugin, service, priority)` | Registers a power-history provider at the given priority. |
+| `unregisterPowerHistoryProvider(service)` | Unregisters a power-history provider from Bukkit's ServicesManager. |
+
 **Relation service**
 
 | Method | Description |
@@ -214,6 +224,26 @@ How power is gained, lost, and used to gate land claims is entirely up to the pr
 | `setPlayerPower(playerUUID, power)` | `boolean` | Overrides the player's current power (clamped by the provider). Returns `false` if the player is unknown. |
 | `getTeamPower(teamId)` | `double` | Total power for the team (typically sum of member power plus any boost). `0.0` if the team is unknown. |
 | `getTeamMaxPower(teamId)` | `double` | Theoretical maximum power for the team (typically `maxPowerPerPlayer * memberCount`). `0.0` if the team is unknown. |
+
+## `TeamsPowerHistoryService` (interface)
+
+Optional extension service for reading and managing power-history entries.
+Providers that support history register via `TeamsAPI.registerPowerHistoryProvider()`.
+Existing `TeamsService` and `TeamsPowerService` implementations are not required to
+support it.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getPlayerPowerHistory(playerUUID, limit)` | `Collection<TeamPowerHistoryEntry>` | Recent entries for a player, newest first. |
+| `getPlayerPowerHistory(playerUUID, fromInclusive, toExclusive, limit)` | `Collection<TeamPowerHistoryEntry>` | Player entries in a time window, newest first. |
+| `getTeamPowerHistory(teamId, limit)` | `Collection<TeamPowerHistoryEntry>` | Recent entries linked to a team, newest first. |
+| `addPowerHistoryEntry(entryId, playerUUID, teamId, delta, type, reason, actorUUID, occurredAt, details)` | `boolean` | Inserts a new history entry. |
+| `updatePowerHistoryEntry(entryId, delta, type, reason, actorUUID, occurredAt, details)` | `boolean` | Updates an existing history entry. |
+| `removePowerHistoryEntry(entryId)` | `boolean` | Deletes one history entry by ID. |
+| `clearPlayerPowerHistory(playerUUID)` | `int` | Deletes all entries for a player; returns removed count. |
+| `clearTeamPowerHistory(teamId)` | `int` | Deletes all entries linked to a team; returns removed count. |
+| `addGainHistoryEntry(...)` | `boolean` | Default helper that records a `GAIN` entry from `PowerGainSource`. |
+| `addLossHistoryEntry(...)` | `boolean` | Default helper that records a `LOSS` entry from `PowerLossCause`. |
 
 ## `TeamsRelationService` (interface)
 
@@ -406,6 +436,32 @@ Helper methods:
 | `getPriority()` | Numeric priority value. Higher = more authority. |
 | `outranks(other)` | Returns `true` if this role has a higher priority than `other`. |
 | `canManage(target)` | Returns `true` if this role can manage members of the `target` role. |
+
+## `TeamPowerHistoryEntry` (interface)
+
+Read-only snapshot of a provider-owned power-history entry.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getEntryId()` | `UUID` | Stable unique identifier for the entry. |
+| `getPlayerUUID()` | `UUID` | Player whose power changed. |
+| `getTeamId()` | `Optional<UUID>` | Team linked to the change, if any. |
+| `getDelta()` | `double` | Signed power delta (positive gain, negative loss). |
+| `getType()` | `TeamPowerHistoryType` | Categorized change type. |
+| `getReason()` | `String` | Provider-defined reason key (recommended lowercase stable keys). |
+| `getActorUUID()` | `Optional<UUID>` | Actor who initiated the change, if applicable. |
+| `getOccurredAt()` | `Instant` | Timestamp of the change. |
+| `getDetails()` | `Optional<String>` | Optional human-readable details text. |
+
+## `TeamPowerHistoryType` (enum)
+
+Classifies the type of a power-history entry.
+
+| Constant | Description |
+|----------|-------------|
+| `GAIN` | Positive power gain entries. |
+| `LOSS` | Power loss entries. |
+| `ADJUSTMENT` | Manual or system corrections. |
 
 ## Events
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ backend server directly.
 - **Optional claim support**: register a `TeamsClaimService` for chunk claims, including
   SafeZone and WarZone territory typing
 - **Optional power support**: register a `TeamsPowerService` to expose team/player power
+- **Optional power-history support**: register a `TeamsPowerHistoryService` so
+  plugins can read, write, and manage power-history entries
 - **Optional relation support**: register a `TeamsRelationService` for ally/truce/neutral/enemy diplomacy
 - **Optional notification support**: register a `TeamsNotificationService` for
   cross-plugin player notifications with built-in and custom string types

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -32,6 +32,8 @@ consumer plugin keeps working without a recompile.
 - **Optional warp service**: providers can expose `TeamsWarpService` for named team warps.
 - **Optional claim service**: providers can expose `TeamsClaimService` for chunk-claim management, including SafeZone and WarZone territory support.
 - **Optional power service**: providers can expose `TeamsPowerService` for player and team power values.
+- **Optional power-history service**: providers can expose `TeamsPowerHistoryService`
+  for reading and managing player/team power-history entries.
 - **Optional relation service**: providers can expose `TeamsRelationService` for inter-team diplomacy (ally/truce/neutral/enemy).
 - **Optional notification service**: providers can expose `TeamsNotificationService` for
   cross-plugin player notifications using built-in enum types and custom string types.
@@ -77,7 +79,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -89,7 +91,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.7.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.8.0'
 }
 ```
 
@@ -241,6 +243,28 @@ TeamsAPI.registerPowerProvider(this, powerService);
 | `getTeamMaxPower(teamId)` | `double` | Maximum combined power the team can hold |
 
 Consumers check availability with `TeamsAPI.isPowerAvailable()` before calling `TeamsAPI.getPowerService()`.
+
+### Power history service (optional)
+
+Register alongside `TeamsService` if your plugin exposes power history:
+
+```java
+TeamsAPI.registerPowerHistoryProvider(this, powerHistoryService);
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getPlayerPowerHistory(playerUUID, limit)` | `Collection<TeamPowerHistoryEntry>` | Recent entries for a player, newest first. |
+| `getPlayerPowerHistory(playerUUID, fromInclusive, toExclusive, limit)` | `Collection<TeamPowerHistoryEntry>` | Player entries in a time window, newest first. |
+| `getTeamPowerHistory(teamId, limit)` | `Collection<TeamPowerHistoryEntry>` | Recent entries linked to a team. |
+| `addPowerHistoryEntry(entryId, playerUUID, teamId, delta, type, reason, actorUUID, occurredAt, details)` | `boolean` | Inserts a history entry. |
+| `updatePowerHistoryEntry(entryId, delta, type, reason, actorUUID, occurredAt, details)` | `boolean` | Updates an existing entry. |
+| `removePowerHistoryEntry(entryId)` | `boolean` | Deletes one entry by ID. |
+| `clearPlayerPowerHistory(playerUUID)` | `int` | Deletes all player entries; returns removed count. |
+| `clearTeamPowerHistory(teamId)` | `int` | Deletes all team-linked entries; returns removed count. |
+
+Consumers check availability with `TeamsAPI.isPowerHistoryAvailable()` before calling
+`TeamsAPI.getPowerHistoryService()`.
 
 ### Relation service (optional)
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -30,6 +30,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 [*][B]Optional warp service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsWarpService[/COLOR] for named team warps.
 [*][B]Optional claim service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsClaimService[/COLOR] for chunk-claim management, including SafeZone and WarZone support.
 [*][B]Optional power service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsPowerService[/COLOR] for player and team power values.
+[*][B]Optional power-history service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsPowerHistoryService[/COLOR] for reading and managing player/team power-history entries.
 [*][B]Optional relation service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsRelationService[/COLOR] for inter-team diplomacy (ally / truce / neutral / enemy).
 [*][B]Optional notification service[/B] -- providers can expose [COLOR=#6cb4ff]TeamsNotificationService[/COLOR] for cross-plugin player notifications with built-in enum types and custom string types.
 [*][B]Custom subcommands[/B] -- any plugin registers a [COLOR=#6cb4ff]TeamsSubcommand[/COLOR] via [COLOR=#6cb4ff]TeamsAPI.registerSubcommand()[/COLOR]; team plugins call [COLOR=#6cb4ff]TeamsAPI.getSubcommands()[/COLOR] in their own command handler to dispatch them without coupling.
@@ -77,7 +78,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -89,7 +90,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:1.7.0'
+    compileOnly 'com.github.ez-plugins:teams-api:1.8.0'
 }
 [/CODE]
 [/SPOILER]
@@ -215,6 +216,21 @@ public void onDisable() {
 [*][COLOR=#6cb4ff]setPlayerPower(playerUUID, power)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Sets the player's power
 [*][COLOR=#6cb4ff]getTeamPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Combined power of all team members
 [*][COLOR=#6cb4ff]getTeamMaxPower(teamId)[/COLOR] -> [COLOR=#ffd700]double[/COLOR] -- Maximum combined power the team can hold
+[/LIST]
+
+[SIZE=4][B]Power history service (optional)[/B][/SIZE]
+
+[COLOR=#aaaaaa]Check availability with [COLOR=#6cb4ff]TeamsAPI.isPowerHistoryAvailable()[/COLOR] before calling [COLOR=#6cb4ff]TeamsAPI.getPowerHistoryService()[/COLOR].[/COLOR]
+
+[LIST]
+[*][COLOR=#6cb4ff]getPlayerPowerHistory(playerUUID, limit)[/COLOR] -> [COLOR=#ffd700]Collection<TeamPowerHistoryEntry>[/COLOR] -- Recent entries for a player, newest first.
+[*][COLOR=#6cb4ff]getPlayerPowerHistory(playerUUID, fromInclusive, toExclusive, limit)[/COLOR] -> [COLOR=#ffd700]Collection<TeamPowerHistoryEntry>[/COLOR] -- Player entries in a time window, newest first.
+[*][COLOR=#6cb4ff]getTeamPowerHistory(teamId, limit)[/COLOR] -> [COLOR=#ffd700]Collection<TeamPowerHistoryEntry>[/COLOR] -- Recent entries linked to a team.
+[*][COLOR=#6cb4ff]addPowerHistoryEntry(entryId, playerUUID, teamId, delta, type, reason, actorUUID, occurredAt, details)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Inserts a history entry.
+[*][COLOR=#6cb4ff]updatePowerHistoryEntry(entryId, delta, type, reason, actorUUID, occurredAt, details)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Updates an existing entry.
+[*][COLOR=#6cb4ff]removePowerHistoryEntry(entryId)[/COLOR] -> [COLOR=#ffd700]boolean[/COLOR] -- Deletes one entry by ID.
+[*][COLOR=#6cb4ff]clearPlayerPowerHistory(playerUUID)[/COLOR] -> [COLOR=#ffd700]int[/COLOR] -- Deletes all player entries; returns removed count.
+[*][COLOR=#6cb4ff]clearTeamPowerHistory(teamId)[/COLOR] -> [COLOR=#ffd700]int[/COLOR] -- Deletes all team-linked entries; returns removed count.
 [/LIST]
 
 [SIZE=4][B]Relation service (optional)[/B][/SIZE]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -52,7 +52,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.7.0";
+    public static final String API_VERSION = "1.8.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }
@@ -534,6 +534,105 @@ public final class TeamsAPI {
         }
 
         Bukkit.getServicesManager().unregister(TeamsPowerService.class, provider);
+    }
+
+    // -------------------------------------------------------------------------
+    // Power history provider registration and lookup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the currently registered {@link TeamsPowerHistoryService} provider, or
+     * {@code null} if no power-history provider has been registered.
+     *
+     * <p>Consumers should check {@link #isPowerHistoryAvailable()} before calling this
+     * method to handle gracefully the case where no team plugin exposes power
+     * history.</p>
+     *
+     * @return the active {@link TeamsPowerHistoryService}, or {@code null} if unavailable
+     */
+    public static TeamsPowerHistoryService getPowerHistoryService() {
+        try {
+            final RegisteredServiceProvider<TeamsPowerHistoryService> reg =
+                Bukkit.getServicesManager().getRegistration(TeamsPowerHistoryService.class);
+
+            return reg != null ? reg.getProvider() : null;
+        }
+        catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns {@code true} if at least one {@link TeamsPowerHistoryService} provider is
+     * currently registered.
+     *
+     * @return {@code true} if a power-history provider is available, {@code false} otherwise
+     */
+    public static boolean isPowerHistoryAvailable() {
+        return getPowerHistoryService() != null;
+    }
+
+    /**
+     * Registers a {@link TeamsPowerHistoryService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at {@link ServicePriority#Normal}.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsPowerHistoryService} implementation; must not be
+     *                 {@code null}
+     */
+    public static void registerPowerHistoryProvider(final Plugin plugin,
+            final TeamsPowerHistoryService provider) {
+        if (plugin == null || provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsPowerHistoryService.class, provider, plugin, ServicePriority.Normal);
+    }
+
+    /**
+     * Registers a {@link TeamsPowerHistoryService} provider with Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager} at the specified priority.
+     *
+     * <p>This method silently ignores {@code null} arguments.</p>
+     *
+     * @param plugin   the plugin registering the provider; must not be {@code null}
+     * @param provider the {@link TeamsPowerHistoryService} implementation; must not be
+     *                 {@code null}
+     * @param priority the {@link ServicePriority} to register at; must not be {@code null}
+     */
+    public static void registerPowerHistoryProvider(
+            final Plugin plugin,
+            final TeamsPowerHistoryService provider,
+            final ServicePriority priority) {
+        if (plugin == null || provider == null || priority == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager()
+            .register(TeamsPowerHistoryService.class, provider, plugin, priority);
+    }
+
+    /**
+     * Unregisters a {@link TeamsPowerHistoryService} provider from Bukkit's
+     * {@link org.bukkit.plugin.ServicesManager}.
+     *
+     * <p>Providers should call this in their plugin's {@code onDisable()} alongside
+     * {@link #unregisterProvider(TeamsService)}.</p>
+     *
+     * <p>This method silently ignores a {@code null} argument.</p>
+     *
+     * @param provider the {@link TeamsPowerHistoryService} provider to unregister;
+     *                 may be {@code null}
+     */
+    public static void unregisterPowerHistoryProvider(final TeamsPowerHistoryService provider) {
+        if (provider == null) {
+            return;
+        }
+
+        Bukkit.getServicesManager().unregister(TeamsPowerHistoryService.class, provider);
     }
 
     // -------------------------------------------------------------------------

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsPowerHistoryService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsPowerHistoryService.java
@@ -1,0 +1,200 @@
+package com.skyblockexp.teamsapi.api;
+
+import com.skyblockexp.teamsapi.model.PowerGainSource;
+import com.skyblockexp.teamsapi.model.PowerLossCause;
+import com.skyblockexp.teamsapi.model.TeamPowerHistoryEntry;
+import com.skyblockexp.teamsapi.model.TeamPowerHistoryType;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Optional extension service for reading and managing power history.
+ *
+ * <p>This interface is independent of {@link TeamsService}. Providers that wish to
+ * expose power history register an implementation separately via
+ * {@link TeamsAPI#registerPowerHistoryProvider(org.bukkit.plugin.Plugin, TeamsPowerHistoryService)}.
+ * Consumers first check availability with {@link TeamsAPI#isPowerHistoryAvailable()}
+ * before calling {@link TeamsAPI#getPowerHistoryService()}.</p>
+ *
+ * <p>Existing providers are not required to implement this interface; omitting it
+ * is a supported configuration and the API will degrade gracefully.</p>
+ */
+public interface TeamsPowerHistoryService {
+
+    /**
+     * Returns recent power-history entries for a player, newest first.
+     *
+     * @param playerUUID the UUID of the player; must not be {@code null}
+     * @param limit      maximum number of entries to return; {@code <= 0} means provider default
+     * @return an unmodifiable collection of entries; never {@code null}
+     */
+    Collection<TeamPowerHistoryEntry> getPlayerPowerHistory(UUID playerUUID, int limit);
+
+    /**
+     * Returns power-history entries for a player within a time window, newest first.
+     *
+     * @param playerUUID    the UUID of the player; must not be {@code null}
+     * @param fromInclusive lower time bound (inclusive); must not be {@code null}
+     * @param toExclusive   upper time bound (exclusive); must not be {@code null}
+     * @param limit         maximum number of entries to return; {@code <= 0} means
+     *                      provider default
+     * @return an unmodifiable collection of entries; never {@code null}
+     */
+    Collection<TeamPowerHistoryEntry> getPlayerPowerHistory(
+            UUID playerUUID,
+            Instant fromInclusive,
+            Instant toExclusive,
+            int limit);
+
+    /**
+     * Returns recent power-history entries associated with a team, newest first.
+     *
+     * @param teamId the UUID of the team; must not be {@code null}
+     * @param limit  maximum number of entries to return; {@code <= 0} means provider default
+     * @return an unmodifiable collection of entries; never {@code null}
+     */
+    Collection<TeamPowerHistoryEntry> getTeamPowerHistory(UUID teamId, int limit);
+
+    /**
+     * Adds a power-history entry.
+     *
+     * <p>Providers may reject duplicates for an existing {@code entryId}.</p>
+     *
+     * @param entryId    stable entry UUID; must not be {@code null}
+     * @param playerUUID player UUID whose power changed; must not be {@code null}
+     * @param teamId     related team UUID; may be {@code null} when not applicable
+     * @param delta      signed power change amount
+     * @param type       history type; must not be {@code null}
+     * @param reason     provider-defined reason key; must not be {@code null}
+     * @param actorUUID  actor UUID who initiated the change; may be {@code null}
+     * @param occurredAt timestamp of the change; must not be {@code null}
+     * @param details    optional details text; may be {@code null}
+     * @return {@code true} if inserted, {@code false} otherwise
+     */
+    boolean addPowerHistoryEntry(UUID entryId,
+            UUID playerUUID,
+            UUID teamId,
+            double delta,
+            TeamPowerHistoryType type,
+            String reason,
+            UUID actorUUID,
+            Instant occurredAt,
+            String details);
+
+    /**
+     * Updates an existing power-history entry.
+     *
+     * @param entryId    stable entry UUID; must not be {@code null}
+     * @param delta      signed power change amount
+     * @param type       history type; must not be {@code null}
+     * @param reason     provider-defined reason key; must not be {@code null}
+     * @param actorUUID  actor UUID who initiated the change; may be {@code null}
+     * @param occurredAt timestamp of the change; must not be {@code null}
+     * @param details    optional details text; may be {@code null}
+     * @return {@code true} if updated, {@code false} when the entry does not exist
+     */
+    boolean updatePowerHistoryEntry(UUID entryId,
+            double delta,
+            TeamPowerHistoryType type,
+            String reason,
+            UUID actorUUID,
+            Instant occurredAt,
+            String details);
+
+    /**
+     * Removes a single history entry by ID.
+     *
+     * @param entryId the entry UUID; must not be {@code null}
+     * @return {@code true} if removed, {@code false} otherwise
+     */
+    boolean removePowerHistoryEntry(UUID entryId);
+
+    /**
+     * Removes all history entries for a player.
+     *
+     * @param playerUUID player UUID; must not be {@code null}
+     * @return the number of removed entries; always {@code >= 0}
+     */
+    int clearPlayerPowerHistory(UUID playerUUID);
+
+    /**
+     * Removes all history entries linked to a team.
+     *
+     * @param teamId team UUID; must not be {@code null}
+     * @return the number of removed entries; always {@code >= 0}
+     */
+    int clearTeamPowerHistory(UUID teamId);
+
+    /**
+     * Convenience helper for recording a gain entry using {@link PowerGainSource}.
+     *
+     * @param entryId    stable entry UUID; must not be {@code null}
+     * @param playerUUID player UUID whose power changed; must not be {@code null}
+     * @param teamId     related team UUID; may be {@code null}
+     * @param delta      positive gain amount
+     * @param source     gain source; must not be {@code null}
+     * @param actorUUID  actor UUID who initiated the change; may be {@code null}
+     * @param occurredAt timestamp of the change; must not be {@code null}
+     * @param details    optional details text; may be {@code null}
+     * @return {@code true} if inserted, {@code false} otherwise
+     */
+    default boolean addGainHistoryEntry(final UUID entryId,
+            final UUID playerUUID,
+            final UUID teamId,
+            final double delta,
+            final PowerGainSource source,
+            final UUID actorUUID,
+            final Instant occurredAt,
+            final String details) {
+        final String reason = source.name().toLowerCase(Locale.ROOT);
+        return addPowerHistoryEntry(
+            entryId,
+            playerUUID,
+            teamId,
+            delta,
+            TeamPowerHistoryType.GAIN,
+            reason,
+            actorUUID,
+            occurredAt,
+            details
+        );
+    }
+
+    /**
+     * Convenience helper for recording a loss entry using {@link PowerLossCause}.
+     *
+     * @param entryId    stable entry UUID; must not be {@code null}
+     * @param playerUUID player UUID whose power changed; must not be {@code null}
+     * @param teamId     related team UUID; may be {@code null}
+     * @param delta      negative loss amount
+     * @param cause      loss cause; must not be {@code null}
+     * @param actorUUID  actor UUID who initiated the change; may be {@code null}
+     * @param occurredAt timestamp of the change; must not be {@code null}
+     * @param details    optional details text; may be {@code null}
+     * @return {@code true} if inserted, {@code false} otherwise
+     */
+    default boolean addLossHistoryEntry(final UUID entryId,
+            final UUID playerUUID,
+            final UUID teamId,
+            final double delta,
+            final PowerLossCause cause,
+            final UUID actorUUID,
+            final Instant occurredAt,
+            final String details) {
+        final String reason = cause.name().toLowerCase(Locale.ROOT);
+        return addPowerHistoryEntry(
+            entryId,
+            playerUUID,
+            teamId,
+            delta,
+            TeamPowerHistoryType.LOSS,
+            reason,
+            actorUUID,
+            occurredAt,
+            details
+        );
+    }
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryEntry.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryEntry.java
@@ -1,0 +1,84 @@
+package com.skyblockexp.teamsapi.model;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Read-only snapshot of a recorded power-history entry.
+ *
+ * <p>Entries are provider-owned and may be backed by a database or in-memory
+ * store. Consumers should treat returned values as immutable snapshots.</p>
+ */
+public interface TeamPowerHistoryEntry {
+
+    /**
+     * Returns the stable unique identifier of this history entry.
+     *
+     * @return the entry UUID; never {@code null}
+     */
+    UUID getEntryId();
+
+    /**
+     * Returns the player whose power changed.
+     *
+     * @return the player's UUID; never {@code null}
+     */
+    UUID getPlayerUUID();
+
+    /**
+     * Returns the team associated with this change, if any.
+     *
+     * @return an optional containing the team UUID when known, otherwise empty
+     */
+    Optional<UUID> getTeamId();
+
+    /**
+     * Returns the signed power delta applied by this entry.
+     *
+     * <p>Positive values indicate gains and negative values indicate losses.</p>
+     *
+     * @return the signed power delta
+     */
+    double getDelta();
+
+    /**
+     * Returns the categorized type of this power change.
+     *
+     * @return the history type; never {@code null}
+     */
+    TeamPowerHistoryType getType();
+
+    /**
+     * Returns a provider-defined reason key for this change.
+     *
+     * <p>Examples: {@code passive}, {@code death}, {@code purchase},
+     * {@code admin_adjustment}. Providers should use stable lowercase keys.</p>
+     *
+     * @return the reason key; never {@code null}
+     */
+    String getReason();
+
+    /**
+     * Returns an optional actor UUID that initiated the change.
+     *
+     * <p>For automated changes this may be empty.</p>
+     *
+     * @return an optional containing the actor UUID, or empty
+     */
+    Optional<UUID> getActorUUID();
+
+    /**
+     * Returns the timestamp of when this power change occurred.
+     *
+     * @return the timestamp; never {@code null}
+     */
+    Instant getOccurredAt();
+
+    /**
+     * Returns an optional human-readable detail string.
+     *
+     * @return an optional details message, or empty
+     */
+    Optional<String> getDetails();
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryType.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryType.java
@@ -1,0 +1,22 @@
+package com.skyblockexp.teamsapi.model;
+
+/**
+ * Classifies the type of a power history entry.
+ */
+public enum TeamPowerHistoryType {
+
+    /**
+     * A positive power gain.
+     */
+    GAIN,
+
+    /**
+     * A negative power change caused by a loss.
+     */
+    LOSS,
+
+    /**
+     * A manual or system correction that may be positive or negative.
+     */
+    ADJUSTMENT
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIPowerHistoryTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIPowerHistoryTest.java
@@ -1,0 +1,166 @@
+package com.skyblockexp.teamsapi.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.plugin.PluginMock;
+
+/**
+ * Unit tests for the {@link TeamsPowerHistoryService} registration methods on
+ * {@link TeamsAPI}.
+ */
+class TeamsAPIPowerHistoryTest {
+
+    /**
+     * Sets up the MockBukkit environment before each test.
+     */
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    /**
+     * Tears down the MockBukkit environment after each test.
+     */
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    /**
+     * isPowerHistoryAvailable_returnsFalse_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#isPowerHistoryAvailable()} returns {@code false} when no provider
+     * has been registered.
+     */
+    @Test
+    void isPowerHistoryAvailable_returnsFalse_whenNoProviderRegistered() {
+        assertFalse(TeamsAPI.isPowerHistoryAvailable());
+    }
+
+    /**
+     * getPowerHistoryService_returnsNull_whenNoProviderRegistered verifies that
+     * {@link TeamsAPI#getPowerHistoryService()} returns {@code null} when no provider
+     * has been registered.
+     */
+    @Test
+    void getPowerHistoryService_returnsNull_whenNoProviderRegistered() {
+        assertNull(TeamsAPI.getPowerHistoryService());
+    }
+
+    /**
+     * registerPowerHistoryProvider_makesServiceAvailable verifies that after
+     * registration the service becomes available.
+     */
+    @Test
+    void registerPowerHistoryProvider_makesServiceAvailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, mockService);
+
+        assertTrue(TeamsAPI.isPowerHistoryAvailable());
+        assertEquals(mockService, TeamsAPI.getPowerHistoryService());
+    }
+
+    /**
+     * unregisterPowerHistoryProvider_makesServiceUnavailable verifies that after
+     * unregistration the service is unavailable.
+     */
+    @Test
+    void unregisterPowerHistoryProvider_makesServiceUnavailable() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, mockService);
+        TeamsAPI.unregisterPowerHistoryProvider(mockService);
+
+        assertFalse(TeamsAPI.isPowerHistoryAvailable());
+    }
+
+    /**
+     * registerPowerHistoryProvider_withNullPlugin_doesNotRegister verifies that null
+     * plugin values are ignored.
+     */
+    @Test
+    void registerPowerHistoryProvider_withNullPlugin_doesNotRegister() {
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(null, mockService);
+
+        assertFalse(TeamsAPI.isPowerHistoryAvailable());
+    }
+
+    /**
+     * registerPowerHistoryProvider_withNullProvider_doesNotRegister verifies that null
+     * providers are ignored.
+     */
+    @Test
+    void registerPowerHistoryProvider_withNullProvider_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, null);
+
+        assertFalse(TeamsAPI.isPowerHistoryAvailable());
+    }
+
+    /**
+     * unregisterPowerHistoryProvider_withNull_doesNotThrow verifies null-safe
+     * unregistration.
+     */
+    @Test
+    void unregisterPowerHistoryProvider_withNull_doesNotThrow() {
+        TeamsAPI.unregisterPowerHistoryProvider(null);
+    }
+
+    /**
+     * registerPowerHistoryProvider_withPriority_registersCorrectly verifies that the
+     * priority overload registers successfully.
+     */
+    @Test
+    void registerPowerHistoryProvider_withPriority_registersCorrectly() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, mockService,
+            org.bukkit.plugin.ServicePriority.Highest);
+
+        assertTrue(TeamsAPI.isPowerHistoryAvailable());
+        assertEquals(mockService, TeamsAPI.getPowerHistoryService());
+    }
+
+    /**
+     * registerPowerHistoryProvider_withPriority_withNullPriority_doesNotRegister verifies
+     * that a null priority is ignored.
+     */
+    @Test
+    void registerPowerHistoryProvider_withPriority_withNullPriority_doesNotRegister() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, mockService, null);
+
+        assertFalse(TeamsAPI.isPowerHistoryAvailable());
+    }
+
+    /**
+     * powerHistoryService_isIndependentOfTeamsService verifies extension independence.
+     */
+    @Test
+    void powerHistoryService_isIndependentOfTeamsService() {
+        final PluginMock plugin = PluginMock.builder().withPluginName("TestPlugin").build();
+        final TeamsPowerHistoryService mockService = mock(TeamsPowerHistoryService.class);
+
+        TeamsAPI.registerPowerHistoryProvider(plugin, mockService);
+
+        assertTrue(TeamsAPI.isPowerHistoryAvailable());
+        assertFalse(TeamsAPI.isAvailable());
+    }
+}

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryTypeTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/model/TeamPowerHistoryTypeTest.java
@@ -1,0 +1,22 @@
+package com.skyblockexp.teamsapi.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TeamPowerHistoryType}.
+ */
+class TeamPowerHistoryTypeTest {
+
+    /**
+     * enumValues_containsExpectedTypes verifies that all history categories are present.
+     */
+    @Test
+    void enumValues_containsExpectedTypes() {
+        assertEquals(3, TeamPowerHistoryType.values().length);
+        assertEquals(TeamPowerHistoryType.GAIN, TeamPowerHistoryType.valueOf("GAIN"));
+        assertEquals(TeamPowerHistoryType.LOSS, TeamPowerHistoryType.valueOf("LOSS"));
+        assertEquals(TeamPowerHistoryType.ADJUSTMENT, TeamPowerHistoryType.valueOf("ADJUSTMENT"));
+    }
+}


### PR DESCRIPTION
### Added

- `TeamsPowerHistoryService` optional extension interface for reading and
  managing power-history entries through TeamsAPI.
- New power-history model types:
  `TeamPowerHistoryEntry` and `TeamPowerHistoryType`
  (`GAIN`, `LOSS`, `ADJUSTMENT`).
- New `TeamsAPI` power-history facade methods:
  `getPowerHistoryService()`, `isPowerHistoryAvailable()`,
  `registerPowerHistoryProvider(plugin, service)`,
  `registerPowerHistoryProvider(plugin, service, priority)`,
  `unregisterPowerHistoryProvider(service)`.
- New tests:
  `TeamsAPIPowerHistoryTest` (service registration/availability/null-safety)
  and `TeamPowerHistoryTypeTest` (enum contract coverage).
- `TeamsAPI.API_VERSION` bumped to `1.8.0`.