### PR TITLE
feat!: add TeamRelation.MEMBER, fix ALLY/TRUCE colors, bump to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.0]
+
+### Added
+
+- `TeamRelation.MEMBER` constant (ordinal 4) representing the same-team relationship.
+  Providers should return `MEMBER` from `getRelation(A, A)` when both team UUIDs are
+  equal. Consumers comparing two players on potentially the same team will now receive
+  a dedicated constant instead of `NEUTRAL`.
+- `TeamRelation` internal `hostilityLevel` field. `isMoreHostileThan()` now uses this
+  field instead of ordinal position, correctly placing `MEMBER` at hostility level -1
+  (less hostile than `ALLY`). Results for the original four constants are unchanged.
+- `isFriendly()` now returns `true` for `MEMBER` in addition to `ALLY` and `TRUCE`.
+- `TeamsAPI.API_VERSION` bumped to `2.0.0`.
+
+### Changed
+
+- **`ALLY` default color**: `§a` (green / `#55FF55`) → `§b` (aqua / `#55FFFF`).
+  This aligns with the standard Factions color convention where green represents
+  same-team membership.
+- **`TRUCE` default color**: `§6` (gold / `#FFAA00`) → `§e` (yellow / `#FFFF55`).
+  Aligns legacy code character with MiniMessage `<yellow>`.
+
+### Migration
+
+The four original ordinals (`ALLY=0`, `TRUCE=1`, `NEUTRAL=2`, `ENEMY=3`) are
+**unchanged**. Code that does not reference `MEMBER` and does not depend on the
+specific color values of `ALLY` or `TRUCE` requires no changes.
+
+Consumers that use `ALLY` or `TRUCE` default colors (via `getLegacyColorCode()`,
+`getDefaultHexColor()`, or `TeamsRelationService.getRelationColor()`) should update
+their color expectations accordingly. Providers that configure their own colors via
+`getRelationColor()` overrides are unaffected.
+
 ## [1.8.0]
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -258,7 +258,7 @@ responded. Whether a relation requires mutual agreement for benefits is provider
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `setRelation(fromTeamId, toTeamId, relation, initiatorUUID)` | `boolean` | Declares a relation from one team toward another. Providers should fire `TeamRelationChangeEvent` before persisting; return `false` if cancelled or either team does not exist. Setting `NEUTRAL` removes a previously declared relation. |
-| `getRelation(fromTeamId, toTeamId)` | `TeamRelation` | Returns the relation declared by `fromTeam` toward `toTeam`. Returns `NEUTRAL` if no explicit relation exists. |
+| `getRelation(fromTeamId, toTeamId)` | `TeamRelation` | Returns the relation declared by `fromTeam` toward `toTeam`. Returns `NEUTRAL` if no explicit relation exists. Providers SHOULD return `MEMBER` when both UUIDs are equal. |
 | `getRelations(teamId)` | `Map<UUID, TeamRelation>` | Returns all non-neutral relations declared by the team. Never `null`; empty if no relations exist. |
 | `clearRelations(teamId)` | `boolean` | Removes all relations declared by or toward the team (e.g. on disband). Returns `false` if the team had no relations. |
 | `areAllies(teamAId, teamBId)` | `boolean` | Default: returns `true` when both teams have declared `ALLY` toward each other. |
@@ -387,15 +387,20 @@ Classifies chunk territory in faction-style claiming systems.
 
 ## `TeamRelation` (enum)
 
-Represents the relationship one team has declared toward another. Ordinal ordering
-(lowest hostility → highest): `ALLY < TRUCE < NEUTRAL < ENEMY`.
+Represents the relationship between two teams, including the same-team case.
+Hostility ordering (lowest → highest): `MEMBER < ALLY < TRUCE < NEUTRAL < ENEMY`.
 
-| Constant | Display name | Legacy color | Hex color | Description |
-|----------|-------------|--------------|-----------|-------------|
-| `ALLY`    | "Ally"    | `§a` (green) | `#55FF55` | Formal alliance — mutual benefits apply. |
-| `TRUCE`   | "Truce"   | `§6` (gold)  | `#FFAA00` | Agreed ceasefire — no active hostility. |
-| `NEUTRAL` | "Neutral" | `§7` (gray)  | `#AAAAAA` | No formal relation (default when none is set). |
-| `ENEMY`   | "Enemy"   | `§c` (red)   | `#FF5555` | Actively hostile. |
+`MEMBER` is declared last in the enum to preserve the original ordinals
+(`ALLY=0, TRUCE=1, NEUTRAL=2, ENEMY=3`). Use `isMoreHostileThan()` rather than
+`ordinal()` for hostility comparisons.
+
+| Constant  | Ordinal | Display name | Legacy color  | Hex color | Description |
+|-----------|---------|-------------|---------------|-----------|-------------|
+| `ALLY`    | 0       | "Ally"      | `§b` (aqua)   | `#55FFFF` | Formal alliance — mutual benefits apply. |
+| `TRUCE`   | 1       | "Truce"     | `§e` (yellow) | `#FFFF55` | Agreed ceasefire — no active hostility. |
+| `NEUTRAL` | 2       | "Neutral"   | `§7` (gray)   | `#AAAAAA` | No formal relation (default when none is set). |
+| `ENEMY`   | 3       | "Enemy"     | `§c` (red)    | `#FF5555` | Actively hostile. |
+| `MEMBER`  | 4       | "Member"    | `§a` (green)  | `#55FF55` | Same team — players are teammates. Providers should return this when both team UUIDs are equal. |
 
 Helper methods:
 
@@ -404,9 +409,9 @@ Helper methods:
 | `getDisplayName()` | `String` | Human-friendly name ("Ally", "Truce", etc.). |
 | `getLegacyColorCode()` | `char` | Legacy color code character; prepend `§` to build the full code: `"§" + rel.getLegacyColorCode()`. |
 | `getDefaultHexColor()` | `String` | Default `#RRGGBB` hex string for Adventure / MiniMessage consumers. |
-| `isFriendly()` | `boolean` | Returns `true` for `ALLY` and `TRUCE`. |
+| `isFriendly()` | `boolean` | Returns `true` for `MEMBER`, `ALLY`, and `TRUCE`. |
 | `isHostile()` | `boolean` | Returns `true` for `ENEMY`. |
-| `isMoreHostileThan(other)` | `boolean` | Returns `true` if this relation has a higher hostility level than `other`. |
+| `isMoreHostileThan(other)` | `boolean` | Returns `true` if this relation has a higher hostility level than `other`. Uses a dedicated field — not `ordinal()`. |
 
 ## `TeamNotificationType` (enum)
 
@@ -508,7 +513,38 @@ All concrete events implement `Cancellable`.
 
 ## Migration notes
 
-### Unreleased
+### 2.0.0
+
+**Breaking changes** — providers and consumers relying on `ALLY` or `TRUCE` default
+colors must update their color references.
+
+- **New `TeamRelation.MEMBER` constant** (ordinal 4) — represents the same-team
+  relationship. Providers should return `MEMBER` from `getRelation(A, A)` when both
+  UUIDs are equal. `isFriendly()` now returns `true` for `MEMBER`.
+- **`ALLY` color changed**: `§a` (green / `#55FF55`) → `§b` (aqua / `#55FFFF`).
+- **`TRUCE` color changed**: `§6` (gold / `#FFAA00`) → `§e` (yellow / `#FFFF55`).
+- **`isMoreHostileThan()` now uses a `hostilityLevel` field** instead of `ordinal()`.
+  Results for the original four constants (`ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`) are
+  identical to previous versions. `MEMBER` has `hostilityLevel = -1` (least hostile).
+- Original four ordinals are **unchanged**: `ALLY=0, TRUCE=1, NEUTRAL=2, ENEMY=3`.
+  Code that does not reference `MEMBER` and does not depend on specific color values
+  requires no changes.
+- `TeamsAPI.API_VERSION` bumped from `1.8.0` to `2.0.0`.
+
+### 1.8.0
+
+Non-breaking addition. No changes required for existing providers or consumers.
+
+- New optional `TeamsPowerHistoryService` interface for reading and managing
+  power-history entries.
+- New model types: `TeamPowerHistoryEntry` and `TeamPowerHistoryType`
+  (`GAIN`, `LOSS`, `ADJUSTMENT`).
+- New `TeamsAPI` static methods: `getPowerHistoryService()`,
+  `isPowerHistoryAvailable()`, `registerPowerHistoryProvider(...)`,
+  `unregisterPowerHistoryProvider(...)`.
+- `TeamsAPI.API_VERSION` bumped from `1.7.0` to `1.8.0`.
+
+### 1.7.0
 
 Non-breaking addition. No changes required for existing providers or consumers.
 
@@ -519,11 +555,6 @@ Non-breaking addition. No changes required for existing providers or consumers.
   `unregisterNotificationProvider(...)`.
 - `TeamsNotificationService` supports both built-in enum types and custom
   string notification types.
-
-### 1.7.0
-
-Non-breaking addition. No changes required for existing providers or consumers.
-
 - New enum: `ClaimTerritoryType` with `WILDERNESS`, `TEAM`, `SAFE_ZONE`, `WAR_ZONE`.
 - `TeamClaim` now includes default methods:
   `getTerritoryType()` and `getOwningTeamId()`.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>1.8.0</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.8.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.8.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.8.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>1.8.0</version>
+        <version>2.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -52,7 +52,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "1.8.0";
+    public static final String API_VERSION = "2.0.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsRelationService.java
@@ -76,10 +76,17 @@ public interface TeamsRelationService {
      *
      * <p>If no explicit relation has been set, {@link TeamRelation#NEUTRAL} is returned.</p>
      *
+     * <p>When both UUIDs refer to the same team (i.e.
+     * {@code fromTeamId.equals(toTeamId)}), implementations SHOULD return
+     * {@link TeamRelation#MEMBER} to signal the same-team relationship. Consumers
+     * querying the relation between two players that may be on the same team should
+     * be prepared to receive {@link TeamRelation#MEMBER} as a result.</p>
+     *
      * @param fromTeamId the UUID of the team whose declaration is queried; must not be {@code null}
      * @param toTeamId   the UUID of the target team; must not be {@code null}
      * @return the declared {@link TeamRelation}; never {@code null};
-     *         {@link TeamRelation#NEUTRAL} if no relation has been set
+     *         {@link TeamRelation#NEUTRAL} if no relation has been set;
+     *         {@link TeamRelation#MEMBER} if both UUIDs refer to the same team
      */
     TeamRelation getRelation(UUID fromTeamId, UUID toTeamId);
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
@@ -1,14 +1,20 @@
 package com.skyblockexp.teamsapi.model;
 
 /**
- * Represents the relationship that one team has declared toward another.
+ * Represents the relationship between two teams, including the special case where
+ * both teams are the same (i.e. the player is on the same team).
  *
- * <p>Relations are used by faction-style plugins to model alliances, truces, and
- * hostility between teams. The default state when no relation has been explicitly
- * set is {@link #NEUTRAL}.</p>
+ * <p>Relations are used by faction-style plugins to model same-team membership,
+ * alliances, truces, and hostility between teams. The default state when no relation
+ * has been explicitly set is {@link #NEUTRAL}.</p>
  *
- * <p>Ordinal ordering (lowest hostility → highest hostility):
- * {@code ALLY < TRUCE < NEUTRAL < ENEMY}</p>
+ * <p>Hostility ordering (lowest → highest):
+ * {@code MEMBER < ALLY < TRUCE < NEUTRAL < ENEMY}</p>
+ *
+ * <p>{@link #MEMBER} is placed last in declaration order to preserve the ordinals of
+ * the original four constants ({@code ALLY=0, TRUCE=1, NEUTRAL=2, ENEMY=3}).
+ * {@link #isMoreHostileThan(TeamRelation)} uses a dedicated {@code hostilityLevel}
+ * field rather than ordinal position, so ordering is always correct.</p>
  *
  * <p>Relations may be directional or symmetric depending on the provider.
  * Consumers should use {@link com.skyblockexp.teamsapi.api.TeamsRelationService}
@@ -21,19 +27,33 @@ package com.skyblockexp.teamsapi.model;
 public enum TeamRelation {
 
     /** The two teams are formal allies — mutual benefits apply. */
-    ALLY("Ally", 'a', "#55FF55"),
+    ALLY("Ally", 'b', "#55FFFF", 0),
 
     /** The two teams have agreed to a temporary truce — no active hostility. */
-    TRUCE("Truce", '6', "#FFAA00"),
+    TRUCE("Truce", 'e', "#FFFF55", 1),
 
     /**
      * No formal relation has been set; neither friendly nor hostile.
      * This is the default state returned when no explicit relation exists.
      */
-    NEUTRAL("Neutral", '7', "#AAAAAA"),
+    NEUTRAL("Neutral", '7', "#AAAAAA", 2),
 
     /** The two teams are actively hostile toward each other. */
-    ENEMY("Enemy", 'c', "#FF5555");
+    ENEMY("Enemy", 'c', "#FF5555", 3),
+
+    /**
+     * The two teams are the same team — the players are teammates.
+     *
+     * <p>Providers should return this constant from
+     * {@link com.skyblockexp.teamsapi.api.TeamsRelationService#getRelation(java.util.UUID,
+     * java.util.UUID)} when both team UUIDs are equal. Consumers comparing two players'
+     * teams should check for this relation to identify teammates.</p>
+     *
+     * <p>This constant is declared last to preserve the ordinals of the original four
+     * constants. Use {@link #isMoreHostileThan(TeamRelation)} for hostility comparisons
+     * rather than {@link #ordinal()}.</p>
+     */
+    MEMBER("Member", 'a', "#55FF55", -1);
 
     // -------------------------------------------------------------------------
     // Fields
@@ -57,6 +77,15 @@ public enum TeamRelation {
      */
     private final String defaultHexColor;
 
+    /**
+     * Explicit hostility level used by {@link #isMoreHostileThan(TeamRelation)}.
+     *
+     * <p>Ordering: MEMBER(-1) &lt; ALLY(0) &lt; TRUCE(1) &lt; NEUTRAL(2) &lt; ENEMY(3).
+     * Using a dedicated field instead of ordinal keeps {@link #MEMBER} at the
+     * correct position in the hostility scale regardless of its declaration order.</p>
+     */
+    private final int hostilityLevel;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -67,12 +96,14 @@ public enum TeamRelation {
      * @param displayName     the human-friendly name; must not be {@code null}
      * @param legacyColorCode the legacy Minecraft color code character (e.g. {@code 'a'} for green)
      * @param defaultHexColor the default hex color string in {@code #RRGGBB} format
+     * @param hostilityLevel  the explicit hostility level used for ordering comparisons
      */
     TeamRelation(final String displayName, final char legacyColorCode,
-            final String defaultHexColor) {
+            final String defaultHexColor, final int hostilityLevel) {
         this.displayName = displayName;
         this.legacyColorCode = legacyColorCode;
         this.defaultHexColor = defaultHexColor;
+        this.hostilityLevel = hostilityLevel;
     }
 
     // -------------------------------------------------------------------------
@@ -82,7 +113,8 @@ public enum TeamRelation {
     /**
      * Returns the human-friendly display name of this relation.
      *
-     * <p>Examples: {@code "Ally"}, {@code "Truce"}, {@code "Neutral"}, {@code "Enemy"}.</p>
+     * <p>Examples: {@code "Ally"}, {@code "Truce"}, {@code "Neutral"}, {@code "Enemy"},
+     * {@code "Member"}.</p>
      *
      * @return the display name; never {@code null}
      */
@@ -98,10 +130,11 @@ public enum TeamRelation {
      *
      * <p>Default color assignments:</p>
      * <ul>
-     *   <li>{@link #ALLY} → {@code 'a'} (green)</li>
-     *   <li>{@link #TRUCE} → {@code '6'} (gold)</li>
+     *   <li>{@link #MEMBER}  → {@code 'a'} (green)</li>
+     *   <li>{@link #ALLY}    → {@code 'b'} (aqua)</li>
+     *   <li>{@link #TRUCE}   → {@code 'e'} (yellow)</li>
      *   <li>{@link #NEUTRAL} → {@code '7'} (gray)</li>
-     *   <li>{@link #ENEMY} → {@code 'c'} (red)</li>
+     *   <li>{@link #ENEMY}   → {@code 'c'} (red)</li>
      * </ul>
      *
      * @return the legacy color code character
@@ -122,10 +155,11 @@ public enum TeamRelation {
      *
      * <p>Default color assignments:</p>
      * <ul>
-     *   <li>{@link #ALLY} → {@code "#55FF55"} (bright green)</li>
-     *   <li>{@link #TRUCE} → {@code "#FFAA00"} (gold)</li>
+     *   <li>{@link #MEMBER}  → {@code "#55FF55"} (green)</li>
+     *   <li>{@link #ALLY}    → {@code "#55FFFF"} (aqua)</li>
+     *   <li>{@link #TRUCE}   → {@code "#FFFF55"} (yellow)</li>
      *   <li>{@link #NEUTRAL} → {@code "#AAAAAA"} (gray)</li>
-     *   <li>{@link #ENEMY} → {@code "#FF5555"} (red)</li>
+     *   <li>{@link #ENEMY}   → {@code "#FF5555"} (red)</li>
      * </ul>
      *
      * @return the hex color string; never {@code null}
@@ -140,12 +174,12 @@ public enum TeamRelation {
 
     /**
      * Returns {@code true} if this relation is considered friendly
-     * (i.e. {@link #ALLY} or {@link #TRUCE}).
+     * (i.e. {@link #MEMBER}, {@link #ALLY}, or {@link #TRUCE}).
      *
-     * @return {@code true} for ALLY and TRUCE, {@code false} otherwise
+     * @return {@code true} for MEMBER, ALLY and TRUCE, {@code false} otherwise
      */
     public boolean isFriendly() {
-        return this == ALLY || this == TRUCE;
+        return this == MEMBER || this == ALLY || this == TRUCE;
     }
 
     /**
@@ -161,12 +195,16 @@ public enum TeamRelation {
     /**
      * Returns {@code true} if this relation has a higher hostility level than {@code other}.
      *
-     * <p>Hostility ordering: ALLY &lt; TRUCE &lt; NEUTRAL &lt; ENEMY.</p>
+     * <p>Hostility ordering: MEMBER &lt; ALLY &lt; TRUCE &lt; NEUTRAL &lt; ENEMY.</p>
+     *
+     * <p>This method uses an explicit {@code hostilityLevel} field rather than
+     * {@link #ordinal()}, so {@link #MEMBER} (declared last) is correctly treated as
+     * the least hostile relation.</p>
      *
      * @param other the relation to compare against; must not be {@code null}
      * @return {@code true} if this relation is more hostile than {@code other}
      */
     public boolean isMoreHostileThan(final TeamRelation other) {
-        return this.ordinal() > other.ordinal();
+        return this.hostilityLevel > other.hostilityLevel;
     }
 }

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/api/TeamsAPIRelationTest.java
@@ -195,6 +195,7 @@ class TeamsAPIRelationTest {
         assertEquals("Truce",   TeamRelation.TRUCE.getDisplayName());
         assertEquals("Neutral", TeamRelation.NEUTRAL.getDisplayName());
         assertEquals("Enemy",   TeamRelation.ENEMY.getDisplayName());
+        assertEquals("Member",  TeamRelation.MEMBER.getDisplayName());
     }
 
     // -------------------------------------------------------------------------
@@ -208,10 +209,11 @@ class TeamsAPIRelationTest {
      */
     @Test
     void teamRelation_getLegacyColorCode_returnsCorrectCode() {
-        assertEquals('a', TeamRelation.ALLY.getLegacyColorCode());
-        assertEquals('6', TeamRelation.TRUCE.getLegacyColorCode());
+        assertEquals('b', TeamRelation.ALLY.getLegacyColorCode());
+        assertEquals('e', TeamRelation.TRUCE.getLegacyColorCode());
         assertEquals('7', TeamRelation.NEUTRAL.getLegacyColorCode());
         assertEquals('c', TeamRelation.ENEMY.getLegacyColorCode());
+        assertEquals('a', TeamRelation.MEMBER.getLegacyColorCode());
     }
 
     // -------------------------------------------------------------------------
@@ -224,10 +226,11 @@ class TeamsAPIRelationTest {
      */
     @Test
     void teamRelation_getDefaultHexColor_returnsCorrectHex() {
-        assertEquals("#55FF55", TeamRelation.ALLY.getDefaultHexColor());
-        assertEquals("#FFAA00", TeamRelation.TRUCE.getDefaultHexColor());
+        assertEquals("#55FFFF", TeamRelation.ALLY.getDefaultHexColor());
+        assertEquals("#FFFF55", TeamRelation.TRUCE.getDefaultHexColor());
         assertEquals("#AAAAAA", TeamRelation.NEUTRAL.getDefaultHexColor());
         assertEquals("#FF5555", TeamRelation.ENEMY.getDefaultHexColor());
+        assertEquals("#55FF55", TeamRelation.MEMBER.getDefaultHexColor());
     }
 
     // -------------------------------------------------------------------------
@@ -322,5 +325,57 @@ class TeamsAPIRelationTest {
 
         assertEquals("#0000FF", service.getRelationColor(TeamRelation.ALLY));
         assertEquals(TeamRelation.ENEMY.getDefaultHexColor(), service.getRelationColor(TeamRelation.ENEMY));
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamRelation enum — isFriendly
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamRelation_isFriendly_returnsTrue_forMemberAllyTruce verifies that
+     * {@link TeamRelation#isFriendly()} returns {@code true} for MEMBER, ALLY, and
+     * TRUCE, and {@code false} for NEUTRAL and ENEMY.
+     */
+    @Test
+    void teamRelation_isFriendly_returnsTrue_forMemberAllyTruce() {
+        assertTrue(TeamRelation.MEMBER.isFriendly());
+        assertTrue(TeamRelation.ALLY.isFriendly());
+        assertTrue(TeamRelation.TRUCE.isFriendly());
+        assertFalse(TeamRelation.NEUTRAL.isFriendly());
+        assertFalse(TeamRelation.ENEMY.isFriendly());
+    }
+
+    // -------------------------------------------------------------------------
+    // TeamRelation enum — isMoreHostileThan
+    // -------------------------------------------------------------------------
+
+    /**
+     * teamRelation_isMoreHostileThan_memberIsLeastHostile verifies that
+     * {@link TeamRelation#MEMBER} is less hostile than every other relation.
+     */
+    @Test
+    void teamRelation_isMoreHostileThan_memberIsLeastHostile() {
+        assertFalse(TeamRelation.MEMBER.isMoreHostileThan(TeamRelation.ALLY));
+        assertFalse(TeamRelation.MEMBER.isMoreHostileThan(TeamRelation.TRUCE));
+        assertFalse(TeamRelation.MEMBER.isMoreHostileThan(TeamRelation.NEUTRAL));
+        assertFalse(TeamRelation.MEMBER.isMoreHostileThan(TeamRelation.ENEMY));
+        assertTrue(TeamRelation.ALLY.isMoreHostileThan(TeamRelation.MEMBER));
+        assertTrue(TeamRelation.ENEMY.isMoreHostileThan(TeamRelation.MEMBER));
+    }
+
+    /**
+     * teamRelation_isMoreHostileThan_preservesExistingOrdering verifies that the
+     * original four-constant hostility ordering (ALLY &lt; TRUCE &lt; NEUTRAL &lt; ENEMY)
+     * is unchanged after the introduction of MEMBER.
+     */
+    @Test
+    void teamRelation_isMoreHostileThan_preservesExistingOrdering() {
+        assertTrue(TeamRelation.TRUCE.isMoreHostileThan(TeamRelation.ALLY));
+        assertTrue(TeamRelation.NEUTRAL.isMoreHostileThan(TeamRelation.TRUCE));
+        assertTrue(TeamRelation.ENEMY.isMoreHostileThan(TeamRelation.NEUTRAL));
+        assertTrue(TeamRelation.ENEMY.isMoreHostileThan(TeamRelation.ALLY));
+        assertFalse(TeamRelation.ALLY.isMoreHostileThan(TeamRelation.TRUCE));
+        assertFalse(TeamRelation.ALLY.isMoreHostileThan(TeamRelation.NEUTRAL));
+        assertFalse(TeamRelation.ALLY.isMoreHostileThan(TeamRelation.ENEMY));
     }
 }


### PR DESCRIPTION
- Add TeamRelation.MEMBER constant (ordinal 4, hostilityLevel -1)
- Fix ALLY color: §a green → §b aqua (#55FFFF)
- Fix TRUCE color: §6 gold → §e yellow (#FFFF55)
- Add hostilityLevel field to TeamRelation; isMoreHostileThan() uses it instead of ordinal() — results unchanged for existing four constants
- isFriendly() now returns true for MEMBER, ALLY, and TRUCE
- Document SHOULD-return-MEMBER contract in TeamsRelationService.getRelation()
- Bump TeamsAPI.API_VERSION and pom.xml to 2.0.0
- Add migration notes for 2.0.0, 1.8.0, and 1.7.0 in docs/api.md
- Add 2.0.0 entry to CHANGELOG.md