### PR TITLE
Add optional RelationNature to TeamRelation with override; add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to TeamsAPI are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.1.0]
+
+### Added
+
+- Optional `RelationNature` enum (`FRIENDLY`, `NEUTRAL`, `HOSTILE`) to the model
+  package. Each `TeamRelation` constant carries a built-in default nature which may
+  be queried with `getDefaultNature()`.
+- Consumer override support: `TeamRelation#setNatureOverride(RelationNature)` and
+  `TeamRelation#getNature()` — allows server or provider code to re-categorise a
+  relation at runtime. Passing `null` to `setNatureOverride` clears the override
+  and restores the builtin default. Overrides are visible JVM-wide because enum
+  constants are singletons.
+- Unit tests: `TeamRelationTest` covering default natures and override behaviour.
+
+### Changed
+
+- `TeamsAPI.API_VERSION` bumped to `2.1.0`.
+
+### Migration
+
+No behavioural changes to existing `TeamRelation` helpers: `isFriendly()` and
+`isHostile()` remain unchanged and existing consumers require no changes. Providers
+that wish to reclassify relations (for example treating `TRUCE` as `NEUTRAL`) may
+call `setNatureOverride(...)` during initialisation.
+
 ## [2.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   package. Each `TeamRelation` constant carries a built-in default nature which may
   be queried with `getDefaultNature()`.
 - Consumer override support: `TeamRelation#setNatureOverride(RelationNature)` and
-  `TeamRelation#getNature()` — allows server or provider code to re-categorise a
+  `TeamRelation#getNature()` - allows server or provider code to re-categorise a
   relation at runtime. Passing `null` to `setNatureOverride` clears the override
   and restores the builtin default. Overrides are visible JVM-wide because enum
   constants are singletons.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your Plugin (consumer)  ->  TeamsAPI (bridge)  ->  Team Plugin (provider)
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -56,7 +56,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:2.0.0'
+    compileOnly 'com.github.ez-plugins:teams-api:2.1.0'
 }
 ```
 
@@ -286,7 +286,14 @@ public void onDisable() {
 }
 ```
 
-`TeamRelation` values (lowest → highest hostility): `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`.
+`TeamRelation` values (lowest → highest hostility): `MEMBER`, `ALLY`, `TRUCE`, `NEUTRAL`, `ENEMY`.
+
+Note: `TeamRelation` now includes an optional classification layer via the
+`RelationNature` enum (`FRIENDLY`, `NEUTRAL`, `HOSTILE`). Each relation constant
+exposes `getDefaultNature()` and `getNature()`; server or provider code may call
+`setNatureOverride(RelationNature)` during initialisation to re-classify relations
+(for example treating `TRUCE` as `NEUTRAL`). `isFriendly()` and `isHostile()` are
+kept unchanged for backwards compatibility.
 
 > **Vault (optional):** `plugin.yml` declares `softdepend: [Vault]`. When Vault is
 > installed the built-in power shop (`/teamsapi power buy`) can charge players.

--- a/docs/api.md
+++ b/docs/api.md
@@ -413,6 +413,31 @@ Helper methods:
 | `isHostile()` | `boolean` | Returns `true` for `ENEMY`. |
 | `isMoreHostileThan(other)` | `boolean` | Returns `true` if this relation has a higher hostility level than `other`. Uses a dedicated field — not `ordinal()`. |
 
+Additional `RelationNature` helpers:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getDefaultNature()` | `RelationNature` | Returns the compile-time default nature assigned to this relation constant. |
+| `getNature()` | `RelationNature` | Returns the effective nature — either the consumer-supplied override (if set) or the default. |
+| `setNatureOverride(nature)` | `void` | Sets or clears (if `null`) a JVM-wide override for the relation's nature. |
+
+## `RelationNature` (enum)
+
+Classifies the broad nature of a `TeamRelation` for server-level policy decisions
+(e.g. whether to allow PvP, display a friendly badge, or apply protections).
+
+| Constant | Description |
+|----------|-------------|
+| `FRIENDLY` | Friendly relations; typical defaults: `MEMBER`, `ALLY`, `TRUCE`. |
+| `NEUTRAL`  | No special treatment. |
+| `HOSTILE`  | Hostile relations; typical default: `ENEMY`. |
+
+Helper methods:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getDisplayName()` | `String` | Human-friendly name for the nature (e.g. "Friendly"). |
+
 ## `TeamNotificationType` (enum)
 
 Built-in notification categories for `TeamsNotificationService`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ permalink: /
 # TeamsAPI
 
 [![JitPack](https://jitpack.io/v/ez-plugins/teams-api.svg)](https://jitpack.io/#ez-plugins/teams-api)
-[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-1.7.0-blue?logo=github)](https://github.com/ez-plugins/teams-api/packages)
+[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-2.1.0-blue?logo=github)](https://github.com/ez-plugins/teams-api/packages)
 
 **TeamsAPI** is a passive bridge plugin for Paper, Spigot, Purpur, and Folia
 servers running Minecraft 1.16+, modelled on [Vault](https://github.com/MilkBowl/VaultAPI).
@@ -64,7 +64,7 @@ backend server directly.
 <dependency>
   <groupId>com.github.ez-plugins</groupId>
   <artifactId>teams-api</artifactId>
-  <version>1.7.0</version>
+  <version>2.1.0</version>
   <scope>provided</scope>
 </dependency>
 ```

--- a/listing/modrinth-hangar.md
+++ b/listing/modrinth-hangar.md
@@ -79,7 +79,7 @@ Add the API artifact to your project via [JitPack](https://jitpack.io/#ez-plugin
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -91,7 +91,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:2.0.0'
+    compileOnly 'com.github.ez-plugins:teams-api:2.1.0'
 }
 ```
 

--- a/listing/spigotmc.bbcode
+++ b/listing/spigotmc.bbcode
@@ -78,7 +78,7 @@ No two plugins need to know about each other. When the team plugin changes, ever
 <dependency>
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <scope>provided</scope>
 </dependency>
 [/CODE]
@@ -90,7 +90,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 dependencies {
-    compileOnly 'com.github.ez-plugins:teams-api:2.0.0'
+    compileOnly 'com.github.ez-plugins:teams-api:2.1.0'
 }
 [/CODE]
 [/SPOILER]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.ez-plugins</groupId>
     <artifactId>teams-api-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>pom</packaging>
     <name>TeamsAPI Parent</name>
     <description>Universal Teams API for Minecraft: bridges team plugins with a clean, timeless interface.</description>

--- a/teams-api-bungeecord/pom.xml
+++ b/teams-api-bungeecord/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-plugin/pom.xml
+++ b/teams-api-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api-velocity/pom.xml
+++ b/teams-api-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/pom.xml
+++ b/teams-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.ez-plugins</groupId>
         <artifactId>teams-api-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/api/TeamsAPI.java
@@ -52,7 +52,7 @@ public final class TeamsAPI {
      * compatibility when the API introduces breaking changes. The version follows
      * Semantic Versioning ({@code MAJOR.MINOR.PATCH}).</p>
      */
-    public static final String API_VERSION = "2.0.0";
+    public static final String API_VERSION = "2.1.0";
 
     /** Suppresses default constructor, ensuring non-instantiability. */
     private TeamsAPI() { }

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/RelationNature.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/RelationNature.java
@@ -1,0 +1,69 @@
+package com.skyblockexp.teamsapi.model;
+
+/**
+ * Represents the broad nature category of a {@link TeamRelation}.
+ *
+ * <p>Each {@link TeamRelation} constant carries a built-in default {@code RelationNature}.
+ * Consumers may override this at runtime via
+ * {@link TeamRelation#setNatureOverride(RelationNature)} to allow server-specific
+ * categorisation without modifying the relation constants themselves.</p>
+ *
+ * <p>Typical use: decide whether to allow PvP, apply buffs, or show a coloured
+ * label without hard-coding checks against every individual {@link TeamRelation}.</p>
+ *
+ * <p>Default mapping:</p>
+ * <ul>
+ *   <li>{@link TeamRelation#MEMBER}  → {@link #FRIENDLY}</li>
+ *   <li>{@link TeamRelation#ALLY}    → {@link #FRIENDLY}</li>
+ *   <li>{@link TeamRelation#TRUCE}   → {@link #FRIENDLY}</li>
+ *   <li>{@link TeamRelation#NEUTRAL} → {@link #NEUTRAL}</li>
+ *   <li>{@link TeamRelation#ENEMY}   → {@link #HOSTILE}</li>
+ * </ul>
+ */
+public enum RelationNature {
+
+    /** Both teams are on friendly terms — benefits or protections may apply. */
+    FRIENDLY("Friendly"),
+
+    /** Neither friendly nor hostile — no special treatment in either direction. */
+    NEUTRAL("Neutral"),
+
+    /** Both teams are in an adversarial state — combat or penalties may apply. */
+    HOSTILE("Hostile");
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    /** Human-friendly display name (e.g. {@code "Friendly"}). */
+    private final String displayName;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a {@link RelationNature} constant with the given display name.
+     *
+     * @param displayName the human-friendly name; must not be {@code null}
+     */
+    RelationNature(final String displayName) {
+        this.displayName = displayName;
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessor
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the human-friendly display name of this nature.
+     *
+     * <p>Examples: {@code "Friendly"}, {@code "Neutral"}, {@code "Hostile"}.</p>
+     *
+     * @return the display name; never {@code null}
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+}

--- a/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
+++ b/teams-api/src/main/java/com/skyblockexp/teamsapi/model/TeamRelation.java
@@ -21,25 +21,27 @@ package com.skyblockexp.teamsapi.model;
  * to query and manage relations.</p>
  *
  * <p>Each constant carries a human-friendly display name, a legacy Minecraft color
- * code character (for use with the {@code §} prefix in chat), and a default hex
- * color string for Adventure / MiniMessage consumers.</p>
+ * code character (for use with the {@code §} prefix in chat), a default hex
+ * color string for Adventure / MiniMessage consumers, and a {@link RelationNature}
+ * that categorises the relation as friendly, neutral, or hostile. The nature may be
+ * overridden per-constant via {@link #setNatureOverride(RelationNature)}.</p>
  */
 public enum TeamRelation {
 
     /** The two teams are formal allies — mutual benefits apply. */
-    ALLY("Ally", 'b', "#55FFFF", 0),
+    ALLY("Ally", 'b', "#55FFFF", 0, RelationNature.FRIENDLY),
 
     /** The two teams have agreed to a temporary truce — no active hostility. */
-    TRUCE("Truce", 'e', "#FFFF55", 1),
+    TRUCE("Truce", 'e', "#FFFF55", 1, RelationNature.FRIENDLY),
 
     /**
      * No formal relation has been set; neither friendly nor hostile.
      * This is the default state returned when no explicit relation exists.
      */
-    NEUTRAL("Neutral", '7', "#AAAAAA", 2),
+    NEUTRAL("Neutral", '7', "#AAAAAA", 2, RelationNature.NEUTRAL),
 
     /** The two teams are actively hostile toward each other. */
-    ENEMY("Enemy", 'c', "#FF5555", 3),
+    ENEMY("Enemy", 'c', "#FF5555", 3, RelationNature.HOSTILE),
 
     /**
      * The two teams are the same team — the players are teammates.
@@ -53,7 +55,7 @@ public enum TeamRelation {
      * constants. Use {@link #isMoreHostileThan(TeamRelation)} for hostility comparisons
      * rather than {@link #ordinal()}.</p>
      */
-    MEMBER("Member", 'a', "#55FF55", -1);
+    MEMBER("Member", 'a', "#55FF55", -1, RelationNature.FRIENDLY);
 
     // -------------------------------------------------------------------------
     // Fields
@@ -86,6 +88,23 @@ public enum TeamRelation {
      */
     private final int hostilityLevel;
 
+    /**
+     * The default nature category assigned to this relation constant at compile time.
+     *
+     * <p>This value is never changed by {@link #setNatureOverride(RelationNature)}; use
+     * {@link #getDefaultNature()} to retrieve it regardless of any active override.</p>
+     */
+    private final RelationNature defaultNature;
+
+    /**
+     * Optional consumer-supplied nature override for this relation constant.
+     *
+     * <p>When non-{@code null}, {@link #getNature()} returns this value instead of the
+     * default. Set to {@code null} via {@link #setNatureOverride(RelationNature)} to
+     * reset to the built-in default.</p>
+     */
+    private volatile RelationNature nature;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -97,13 +116,16 @@ public enum TeamRelation {
      * @param legacyColorCode the legacy Minecraft color code character (e.g. {@code 'a'} for green)
      * @param defaultHexColor the default hex color string in {@code #RRGGBB} format
      * @param hostilityLevel  the explicit hostility level used for ordering comparisons
+     * @param defaultNature   the default {@link RelationNature} for this constant; must not be {@code null}
      */
     TeamRelation(final String displayName, final char legacyColorCode,
-            final String defaultHexColor, final int hostilityLevel) {
+            final String defaultHexColor, final int hostilityLevel,
+            final RelationNature defaultNature) {
         this.displayName = displayName;
         this.legacyColorCode = legacyColorCode;
         this.defaultHexColor = defaultHexColor;
         this.hostilityLevel = hostilityLevel;
+        this.defaultNature = defaultNature;
     }
 
     // -------------------------------------------------------------------------
@@ -207,4 +229,53 @@ public enum TeamRelation {
     public boolean isMoreHostileThan(final TeamRelation other) {
         return this.hostilityLevel > other.hostilityLevel;
     }
+
+    // -------------------------------------------------------------------------
+    // Nature helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns the default {@link RelationNature} built into this constant.
+     *
+     * <p>This value is set at compile time and is never affected by
+     * {@link #setNatureOverride(RelationNature)}. It reflects the semantic
+     * category that this relation represents by default.</p>
+     *
+     * @return the default nature; never {@code null}
+     */
+    public RelationNature getDefaultNature() {
+        return defaultNature;
+    }
+
+    /**
+     * Returns the effective {@link RelationNature} for this relation.
+     *
+     * <p>If a consumer override is set via {@link #setNatureOverride(RelationNature)},
+     * that value is returned. Otherwise the default nature built into this constant
+     * is returned.</p>
+     *
+     * @return the effective nature; never {@code null}
+     */
+    public RelationNature getNature() {
+        final RelationNature override = nature;
+        return override != null ? override : defaultNature;
+    }
+
+    /**
+     * Sets a consumer-supplied override for the {@link RelationNature} of this constant.
+     *
+     * <p>Passing {@code null} clears any existing override and restores the built-in
+     * default returned by {@link #getDefaultNature()}.</p>
+     *
+     * <p>Because {@link TeamRelation} constants are JVM singletons, this override is
+     * visible server-wide. Providers or server administrators may call this during
+     * initialisation to re-categorise relations (e.g. treating {@link #TRUCE} as
+     * {@link RelationNature#NEUTRAL}).</p>
+     *
+     * @param nature the override nature, or {@code null} to restore the default
+     */
+    public void setNatureOverride(final RelationNature nature) {
+        this.nature = nature;
+    }
+
 }

--- a/teams-api/src/test/java/com/skyblockexp/teamsapi/model/TeamRelationTest.java
+++ b/teams-api/src/test/java/com/skyblockexp/teamsapi/model/TeamRelationTest.java
@@ -1,0 +1,86 @@
+package com.skyblockexp.teamsapi.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TeamRelation} nature-override functionality.
+ *
+ * <p>Tests verify the default natures, override mechanics via
+ * {@link TeamRelation#setNatureOverride(RelationNature)}, and that
+ * {@link TeamRelation#getDefaultNature()} is unaffected by overrides.</p>
+ */
+class TeamRelationTest {
+
+    /**
+     * Clears all nature overrides after each test to avoid cross-test contamination,
+     * since {@link TeamRelation} constants are JVM singletons.
+     */
+    @AfterEach
+    void clearAllOverrides() {
+        for (final TeamRelation relation : TeamRelation.values()) {
+            relation.setNatureOverride(null);
+        }
+    }
+
+    /**
+     * getNature_returnsDefaultNature_whenNoOverrideSet verifies that each relation
+     * constant returns its expected default {@link RelationNature} when no override
+     * has been set.
+     */
+    @Test
+    void getNature_returnsDefaultNature_whenNoOverrideSet() {
+        assertEquals(RelationNature.FRIENDLY, TeamRelation.MEMBER.getNature());
+        assertEquals(RelationNature.FRIENDLY, TeamRelation.ALLY.getNature());
+        assertEquals(RelationNature.FRIENDLY, TeamRelation.TRUCE.getNature());
+        assertEquals(RelationNature.NEUTRAL, TeamRelation.NEUTRAL.getNature());
+        assertEquals(RelationNature.HOSTILE, TeamRelation.ENEMY.getNature());
+    }
+
+    /**
+     * getNature_returnsOverrideNature_whenOverrideIsSet verifies that
+     * {@link TeamRelation#getNature()} returns the consumer-supplied override after
+     * {@link TeamRelation#setNatureOverride(RelationNature)} has been called.
+     */
+    @Test
+    void getNature_returnsOverrideNature_whenOverrideIsSet() {
+        TeamRelation.TRUCE.setNatureOverride(RelationNature.NEUTRAL);
+        assertEquals(RelationNature.NEUTRAL, TeamRelation.TRUCE.getNature());
+    }
+
+    /**
+     * setNatureOverride_withNull_clearsOverride verifies that passing {@code null}
+     * to {@link TeamRelation#setNatureOverride(RelationNature)} removes any existing
+     * override and restores the default nature.
+     */
+    @Test
+    void setNatureOverride_withNull_clearsOverride() {
+        TeamRelation.ALLY.setNatureOverride(RelationNature.HOSTILE);
+        TeamRelation.ALLY.setNatureOverride(null);
+        assertEquals(RelationNature.FRIENDLY, TeamRelation.ALLY.getNature());
+    }
+
+    /**
+     * getDefaultNature_alwaysReturnsOriginalDefault_evenAfterOverride verifies that
+     * {@link TeamRelation#getDefaultNature()} is never affected by
+     * {@link TeamRelation#setNatureOverride(RelationNature)}.
+     */
+    @Test
+    void getDefaultNature_alwaysReturnsOriginalDefault_evenAfterOverride() {
+        TeamRelation.ENEMY.setNatureOverride(RelationNature.NEUTRAL);
+        assertEquals(RelationNature.HOSTILE, TeamRelation.ENEMY.getDefaultNature());
+    }
+
+    /**
+     * setNatureOverride_independentPerConstant verifies that overriding one constant's
+     * nature does not affect any other constant.
+     */
+    @Test
+    void setNatureOverride_independentPerConstant() {
+        TeamRelation.ALLY.setNatureOverride(RelationNature.HOSTILE);
+        assertEquals(RelationNature.NEUTRAL, TeamRelation.NEUTRAL.getNature());
+    }
+
+}


### PR DESCRIPTION
### Added

- Optional `RelationNature` enum (`FRIENDLY`, `NEUTRAL`, `HOSTILE`) to the model
  package. Each `TeamRelation` constant carries a built-in default nature which may
  be queried with `getDefaultNature()`.
- Consumer override support: `TeamRelation#setNatureOverride(RelationNature)` and
  `TeamRelation#getNature()` — allows server or provider code to re-categorise a
  relation at runtime. Passing `null` to `setNatureOverride` clears the override
  and restores the builtin default. Overrides are visible JVM-wide because enum
  constants are singletons.
- Unit tests: `TeamRelationTest` covering default natures and override behaviour.

### Changed

- `TeamsAPI.API_VERSION` bumped to `2.1.0`.

### Migration

No behavioural changes to existing `TeamRelation` helpers: `isFriendly()` and
`isHostile()` remain unchanged and existing consumers require no changes. Providers
that wish to reclassify relations (for example treating `TRUCE` as `NEUTRAL`) may
call `setNatureOverride(...)` during initialisation.